### PR TITLE
GitHub: Fix paths-ignore for Rust PR testing

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,10 +3,10 @@ name: Rust
 on:
   push:
     branches: [ master ]
-    paths-ignore: ['swift']
+    paths-ignore: ['swift/**']
   pull_request:
     branches: [ master ]
-    paths-ignore: ['swift']
+    paths-ignore: ['swift/**']
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
There's no reason to re-test Rust things for changes in Swift.