### PR TITLE
require explicit conversions to and from address::DeviceId

### DIFF
--- a/rust/bridge/ffi/src/lib.rs
+++ b/rust/bridge/ffi/src/lib.rs
@@ -182,7 +182,7 @@ pub unsafe extern "C" fn signal_sealed_session_cipher_decrypt(
             timestamp,
             local_e164,
             local_uuid,
-            local_device_id,
+            local_device_id.into(),
             &mut identity_store,
             &mut session_store,
             &mut prekey_store,
@@ -194,7 +194,7 @@ pub unsafe extern "C" fn signal_sealed_session_cipher_decrypt(
 
         write_optional_cstr_to(sender_e164, Ok(decrypted.sender_e164))?;
         write_cstr_to(sender_uuid, Ok(decrypted.sender_uuid))?;
-        write_result_to(sender_device_id, decrypted.device_id)?;
+        write_result_to(sender_device_id, u32::from(decrypted.device_id))?;
         write_bytearray_to(out, out_len, Some(decrypted.message))
     })
 }

--- a/rust/bridge/shared/src/ffi/storage.rs
+++ b/rust/bridge/shared/src/ffi/storage.rs
@@ -197,12 +197,12 @@ pub struct FfiPreKeyStoreStruct {
 impl PreKeyStore for &FfiPreKeyStoreStruct {
     async fn get_pre_key(
         &self,
-        prekey_id: u32,
+        prekey_id: PreKeyId,
         ctx: Context,
     ) -> Result<PreKeyRecord, SignalProtocolError> {
         let ctx = ctx.unwrap_or(std::ptr::null_mut());
         let mut record = std::ptr::null_mut();
-        let result = (self.load_pre_key)(self.ctx, &mut record, prekey_id, ctx);
+        let result = (self.load_pre_key)(self.ctx, &mut record, prekey_id.into(), ctx);
 
         if let Some(error) = CallbackError::check(result) {
             return Err(SignalProtocolError::ApplicationCallbackError(
@@ -221,12 +221,12 @@ impl PreKeyStore for &FfiPreKeyStoreStruct {
 
     async fn save_pre_key(
         &mut self,
-        prekey_id: u32,
+        prekey_id: PreKeyId,
         record: &PreKeyRecord,
         ctx: Context,
     ) -> Result<(), SignalProtocolError> {
         let ctx = ctx.unwrap_or(std::ptr::null_mut());
-        let result = (self.store_pre_key)(self.ctx, prekey_id, &*record, ctx);
+        let result = (self.store_pre_key)(self.ctx, prekey_id.into(), &*record, ctx);
 
         if let Some(error) = CallbackError::check(result) {
             return Err(SignalProtocolError::ApplicationCallbackError(
@@ -240,11 +240,11 @@ impl PreKeyStore for &FfiPreKeyStoreStruct {
 
     async fn remove_pre_key(
         &mut self,
-        prekey_id: u32,
+        prekey_id: PreKeyId,
         ctx: Context,
     ) -> Result<(), SignalProtocolError> {
         let ctx = ctx.unwrap_or(std::ptr::null_mut());
-        let result = (self.remove_pre_key)(self.ctx, prekey_id, ctx);
+        let result = (self.remove_pre_key)(self.ctx, prekey_id.into(), ctx);
 
         if let Some(error) = CallbackError::check(result) {
             return Err(SignalProtocolError::ApplicationCallbackError(
@@ -282,12 +282,12 @@ pub struct FfiSignedPreKeyStoreStruct {
 impl SignedPreKeyStore for &FfiSignedPreKeyStoreStruct {
     async fn get_signed_pre_key(
         &self,
-        prekey_id: u32,
+        prekey_id: SignedPreKeyId,
         ctx: Context,
     ) -> Result<SignedPreKeyRecord, SignalProtocolError> {
         let ctx = ctx.unwrap_or(std::ptr::null_mut());
         let mut record = std::ptr::null_mut();
-        let result = (self.load_signed_pre_key)(self.ctx, &mut record, prekey_id, ctx);
+        let result = (self.load_signed_pre_key)(self.ctx, &mut record, prekey_id.into(), ctx);
 
         if let Some(error) = CallbackError::check(result) {
             return Err(SignalProtocolError::ApplicationCallbackError(
@@ -307,12 +307,12 @@ impl SignedPreKeyStore for &FfiSignedPreKeyStoreStruct {
 
     async fn save_signed_pre_key(
         &mut self,
-        prekey_id: u32,
+        prekey_id: SignedPreKeyId,
         record: &SignedPreKeyRecord,
         ctx: Context,
     ) -> Result<(), SignalProtocolError> {
         let ctx = ctx.unwrap_or(std::ptr::null_mut());
-        let result = (self.store_signed_pre_key)(self.ctx, prekey_id, &*record, ctx);
+        let result = (self.store_signed_pre_key)(self.ctx, prekey_id.into(), &*record, ctx);
 
         if let Some(error) = CallbackError::check(result) {
             return Err(SignalProtocolError::ApplicationCallbackError(

--- a/rust/bridge/shared/src/jni/storage.rs
+++ b/rust/bridge/shared/src/jni/storage.rs
@@ -253,27 +253,27 @@ impl<'a> JniPreKeyStore<'a> {
 impl<'a> PreKeyStore for JniPreKeyStore<'a> {
     async fn get_pre_key(
         &self,
-        prekey_id: u32,
+        prekey_id: PreKeyId,
         _ctx: Context,
     ) -> Result<PreKeyRecord, SignalProtocolError> {
-        Ok(self.do_get_pre_key(prekey_id)?)
+        Ok(self.do_get_pre_key(prekey_id.into())?)
     }
 
     async fn save_pre_key(
         &mut self,
-        prekey_id: u32,
+        prekey_id: PreKeyId,
         record: &PreKeyRecord,
         _ctx: Context,
     ) -> Result<(), SignalProtocolError> {
-        Ok(self.do_save_pre_key(prekey_id, record)?)
+        Ok(self.do_save_pre_key(prekey_id.into(), record)?)
     }
 
     async fn remove_pre_key(
         &mut self,
-        prekey_id: u32,
+        prekey_id: PreKeyId,
         _ctx: Context,
     ) -> Result<(), SignalProtocolError> {
-        Ok(self.do_remove_pre_key(prekey_id)?)
+        Ok(self.do_remove_pre_key(prekey_id.into())?)
     }
 }
 
@@ -331,19 +331,19 @@ impl<'a> JniSignedPreKeyStore<'a> {
 impl<'a> SignedPreKeyStore for JniSignedPreKeyStore<'a> {
     async fn get_signed_pre_key(
         &self,
-        prekey_id: u32,
+        prekey_id: SignedPreKeyId,
         _ctx: Context,
     ) -> Result<SignedPreKeyRecord, SignalProtocolError> {
-        Ok(self.do_get_signed_pre_key(prekey_id)?)
+        Ok(self.do_get_signed_pre_key(prekey_id.into())?)
     }
 
     async fn save_signed_pre_key(
         &mut self,
-        prekey_id: u32,
+        prekey_id: SignedPreKeyId,
         record: &SignedPreKeyRecord,
         _ctx: Context,
     ) -> Result<(), SignalProtocolError> {
-        Ok(self.do_save_signed_pre_key(prekey_id, record)?)
+        Ok(self.do_save_signed_pre_key(prekey_id.into(), record)?)
     }
 }
 

--- a/rust/bridge/shared/src/node/storage.rs
+++ b/rust/bridge/shared/src/node/storage.rs
@@ -105,31 +105,31 @@ impl Finalize for NodePreKeyStore {
 impl PreKeyStore for NodePreKeyStore {
     async fn get_pre_key(
         &self,
-        pre_key_id: u32,
+        pre_key_id: PreKeyId,
         _ctx: libsignal_protocol::Context,
     ) -> Result<PreKeyRecord, SignalProtocolError> {
-        self.do_get_pre_key(pre_key_id)
+        self.do_get_pre_key(pre_key_id.into())
             .await
             .map_err(|s| js_error_to_rust("getPreKey", s))
     }
 
     async fn save_pre_key(
         &mut self,
-        pre_key_id: u32,
+        pre_key_id: PreKeyId,
         record: &PreKeyRecord,
         _ctx: libsignal_protocol::Context,
     ) -> Result<(), SignalProtocolError> {
-        self.do_save_pre_key(pre_key_id, record.clone())
+        self.do_save_pre_key(pre_key_id.into(), record.clone())
             .await
             .map_err(|s| js_error_to_rust("savePreKey", s))
     }
 
     async fn remove_pre_key(
         &mut self,
-        pre_key_id: u32,
+        pre_key_id: PreKeyId,
         _ctx: libsignal_protocol::Context,
     ) -> Result<(), SignalProtocolError> {
-        self.do_remove_pre_key(pre_key_id)
+        self.do_remove_pre_key(pre_key_id.into())
             .await
             .map_err(|s| js_error_to_rust("removePreKey", s))
     }
@@ -210,21 +210,21 @@ impl Finalize for NodeSignedPreKeyStore {
 impl SignedPreKeyStore for NodeSignedPreKeyStore {
     async fn get_signed_pre_key(
         &self,
-        signed_pre_key_id: u32,
+        signed_pre_key_id: SignedPreKeyId,
         _ctx: libsignal_protocol::Context,
     ) -> Result<SignedPreKeyRecord, SignalProtocolError> {
-        self.do_get_signed_pre_key(signed_pre_key_id)
+        self.do_get_signed_pre_key(signed_pre_key_id.into())
             .await
             .map_err(|s| js_error_to_rust("getSignedPreKey", s))
     }
 
     async fn save_signed_pre_key(
         &mut self,
-        signed_pre_key_id: u32,
+        signed_pre_key_id: SignedPreKeyId,
         record: &SignedPreKeyRecord,
         _ctx: libsignal_protocol::Context,
     ) -> Result<(), SignalProtocolError> {
-        self.do_save_signed_pre_key(signed_pre_key_id, record.clone())
+        self.do_save_signed_pre_key(signed_pre_key_id.into(), record.clone())
             .await
             .map_err(|s| js_error_to_rust("saveSignedPreKey", s))
     }

--- a/rust/protocol/benches/ratchet.rs
+++ b/rust/protocol/benches/ratchet.rs
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Signal Messenger, LLC.
+// Copyright 2020-2022 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
@@ -20,7 +20,7 @@ pub fn ratchet_forward_result(c: &mut Criterion) -> Result<(), SignalProtocolErr
 
     let mut csprng = rand::rngs::OsRng;
 
-    let sender_address = ProtocolAddress::new("+14159999111".to_owned(), 1);
+    let sender_address = ProtocolAddress::new("+14159999111".to_owned(), 1.into());
     let distribution_id = Uuid::from_u128(0xd1d1d1d1_7000_11eb_b32a_33b8a8a487a6);
 
     let mut alice_store = support::test_in_memory_protocol_store()?;

--- a/rust/protocol/benches/sealed_sender.rs
+++ b/rust/protocol/benches/sealed_sender.rs
@@ -16,8 +16,10 @@ mod support;
 pub fn v1(c: &mut Criterion) {
     let mut rng = OsRng;
 
-    let alice_address = ProtocolAddress::new("9d0652a3-dcc3-4d11-975f-74d61598733f".to_owned(), 1);
-    let bob_address = ProtocolAddress::new("796abedb-ca4e-4f18-8803-1fde5b921f9f".to_owned(), 1);
+    let alice_address =
+        ProtocolAddress::new("9d0652a3-dcc3-4d11-975f-74d61598733f".to_owned(), 1.into());
+    let bob_address =
+        ProtocolAddress::new("796abedb-ca4e-4f18-8803-1fde5b921f9f".to_owned(), 1.into());
 
     let mut alice_store = support::test_in_memory_protocol_store().expect("brand new store");
     let mut bob_store = support::test_in_memory_protocol_store().expect("brand new store");
@@ -104,8 +106,10 @@ pub fn v1(c: &mut Criterion) {
 pub fn v2(c: &mut Criterion) {
     let mut rng = OsRng;
 
-    let alice_address = ProtocolAddress::new("9d0652a3-dcc3-4d11-975f-74d61598733f".to_owned(), 1);
-    let bob_address = ProtocolAddress::new("796abedb-ca4e-4f18-8803-1fde5b921f9f".to_owned(), 1);
+    let alice_address =
+        ProtocolAddress::new("9d0652a3-dcc3-4d11-975f-74d61598733f".to_owned(), 1.into());
+    let bob_address =
+        ProtocolAddress::new("796abedb-ca4e-4f18-8803-1fde5b921f9f".to_owned(), 1.into());
 
     let mut alice_store = support::test_in_memory_protocol_store().expect("brand new store");
     let mut bob_store = support::test_in_memory_protocol_store().expect("brand new store");
@@ -201,7 +205,7 @@ pub fn v2(c: &mut Criterion) {
     // Fill out additional recipients.
     let mut recipients = vec![bob_address.clone()];
     while recipients.len() < 10 {
-        let next_address = ProtocolAddress::new(Uuid::from_bytes(rng.gen()).to_string(), 1);
+        let next_address = ProtocolAddress::new(Uuid::from_bytes(rng.gen()).to_string(), 1.into());
 
         let mut next_store = support::test_in_memory_protocol_store().expect("brand new store");
 

--- a/rust/protocol/benches/session.rs
+++ b/rust/protocol/benches/session.rs
@@ -14,8 +14,8 @@ mod support;
 pub fn session_encrypt_result(c: &mut Criterion) -> Result<(), SignalProtocolError> {
     let (alice_session_record, bob_session_record) = support::initialize_sessions_v3()?;
 
-    let alice_address = ProtocolAddress::new("+14159999999".to_owned(), 1);
-    let bob_address = ProtocolAddress::new("+14158888888".to_owned(), 1);
+    let alice_address = ProtocolAddress::new("+14159999999".to_owned(), 1.into());
+    let bob_address = ProtocolAddress::new("+14158888888".to_owned(), 1.into());
 
     let mut alice_store = support::test_in_memory_protocol_store()?;
     let mut bob_store = support::test_in_memory_protocol_store()?;
@@ -98,9 +98,9 @@ pub fn session_encrypt_result(c: &mut Criterion) -> Result<(), SignalProtocolErr
             .get_local_registration_id(None)
             .now_or_never()
             .expect("sync")?,
-        1,                 // device id
-        None,              // pre key
-        signed_pre_key_id, // signed pre key id
+        1.into(),                 // device id
+        None,                     // pre key
+        signed_pre_key_id.into(), // signed pre key id
         bob_signed_pre_key_pair.public_key,
         bob_signed_pre_key_signature.to_vec(),
         *bob_store
@@ -112,9 +112,9 @@ pub fn session_encrypt_result(c: &mut Criterion) -> Result<(), SignalProtocolErr
 
     bob_store
         .save_signed_pre_key(
-            signed_pre_key_id,
+            signed_pre_key_id.into(),
             &SignedPreKeyRecord::new(
-                signed_pre_key_id,
+                signed_pre_key_id.into(),
                 /*timestamp*/ 42,
                 &bob_signed_pre_key_pair,
                 &bob_signed_pre_key_signature,
@@ -183,8 +183,8 @@ pub fn session_encrypt_result(c: &mut Criterion) -> Result<(), SignalProtocolErr
 pub fn session_encrypt_decrypt_result(c: &mut Criterion) -> Result<(), SignalProtocolError> {
     let (alice_session_record, bob_session_record) = support::initialize_sessions_v3()?;
 
-    let alice_address = ProtocolAddress::new("+14159999999".to_owned(), 1);
-    let bob_address = ProtocolAddress::new("+14158888888".to_owned(), 1);
+    let alice_address = ProtocolAddress::new("+14159999999".to_owned(), 1.into());
+    let bob_address = ProtocolAddress::new("+14158888888".to_owned(), 1.into());
 
     let mut alice_store = support::test_in_memory_protocol_store()?;
     let mut bob_store = support::test_in_memory_protocol_store()?;

--- a/rust/protocol/fuzz/fuzz_targets/interaction.rs
+++ b/rust/protocol/fuzz/fuzz_targets/interaction.rs
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 Signal Messenger, LLC.
+// Copyright 2021-2022 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
@@ -40,11 +40,11 @@ impl Participant {
             .calculate_signature(&their_signed_pre_key_public, rng)
             .unwrap();
 
-        let signed_pre_key_id = rng.gen_range(0, 0xFF_FFFF);
+        let signed_pre_key_id: SignedPreKeyId = rng.gen_range(0, 0xFF_FFFF).into();
 
         them.store
             .save_signed_pre_key(
-                signed_pre_key_id,
+                signed_pre_key_id.into(),
                 &SignedPreKeyRecord::new(
                     signed_pre_key_id,
                     /*timestamp*/ 42,
@@ -57,7 +57,7 @@ impl Participant {
             .unwrap();
 
         let pre_key_info = if use_one_time_pre_key {
-            let pre_key_id = rng.gen_range(0, 0xFF_FFFF);
+            let pre_key_id: PreKeyId = rng.gen_range(0, 0xFF_FFFF).into();
             let one_time_pre_key = KeyPair::generate(rng);
 
             them.store
@@ -75,9 +75,9 @@ impl Participant {
 
         let their_pre_key_bundle = PreKeyBundle::new(
             them.store.get_local_registration_id(None).await.unwrap(),
-            1, // device id
-            pre_key_info,
-            signed_pre_key_id,
+            1.into(), // device id
+            pre_key_info.into(),
+            signed_pre_key_id.into(),
             their_signed_pre_key_pair.public_key,
             their_signed_pre_key_signature.into_vec(),
             *them
@@ -188,7 +188,7 @@ fuzz_target!(|data: (u64, &[u8])| {
 
         let mut alice = Participant {
             name: "alice",
-            address: ProtocolAddress::new("+14151111111".to_owned(), 1),
+            address: ProtocolAddress::new("+14151111111".to_owned(), 1.into()),
             store: InMemSignalProtocolStore::new(
                 IdentityKeyPair::generate(&mut csprng),
                 csprng.gen(),
@@ -199,7 +199,7 @@ fuzz_target!(|data: (u64, &[u8])| {
         };
         let mut bob = Participant {
             name: "bob",
-            address: ProtocolAddress::new("+14151111112".to_owned(), 1),
+            address: ProtocolAddress::new("+14151111112".to_owned(), 1.into()),
             store: InMemSignalProtocolStore::new(
                 IdentityKeyPair::generate(&mut csprng),
                 csprng.gen(),

--- a/rust/protocol/src/address.rs
+++ b/rust/protocol/src/address.rs
@@ -1,5 +1,5 @@
 //
-// Copyright 2020-2021 Signal Messenger, LLC.
+// Copyright 2020-2022 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
@@ -16,7 +16,26 @@ use std::fmt;
 /// represents some user.
 ///
 /// Used in [ProtocolAddress].
-pub type DeviceId = u32;
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
+pub struct DeviceId(u32);
+
+impl From<u32> for DeviceId {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<DeviceId> for u32 {
+    fn from(value: DeviceId) -> Self {
+        value.0
+    }
+}
+
+impl fmt::Display for DeviceId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 /// Represents a unique Signal client instance as `(<user ID>, <device ID>)` pair.
 #[derive(Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]

--- a/rust/protocol/src/lib.rs
+++ b/rust/protocol/src/lib.rs
@@ -73,7 +73,9 @@ pub use {
     session_cipher::{
         message_decrypt, message_decrypt_prekey, message_decrypt_signal, message_encrypt,
     },
-    state::{PreKeyBundle, PreKeyRecord, SessionRecord, SignedPreKeyRecord},
+    state::{
+        PreKeyBundle, PreKeyId, PreKeyRecord, SessionRecord, SignedPreKeyId, SignedPreKeyRecord,
+    },
     storage::{
         Context, Direction, IdentityKeyStore, InMemIdentityKeyStore, InMemPreKeyStore,
         InMemSenderKeyStore, InMemSessionStore, InMemSignalProtocolStore, InMemSignedPreKeyStore,

--- a/rust/protocol/src/protocol.rs
+++ b/rust/protocol/src/protocol.rs
@@ -4,6 +4,7 @@
 //
 
 use crate::proto;
+use crate::state::{PreKeyId, SignedPreKeyId};
 use crate::{IdentityKey, PrivateKey, PublicKey, Result, SignalProtocolError};
 
 use std::convert::TryFrom;
@@ -236,8 +237,8 @@ impl TryFrom<&[u8]> for SignalMessage {
 pub struct PreKeySignalMessage {
     message_version: u8,
     registration_id: u32,
-    pre_key_id: Option<u32>,
-    signed_pre_key_id: u32,
+    pre_key_id: Option<PreKeyId>,
+    signed_pre_key_id: SignedPreKeyId,
     base_key: PublicKey,
     identity_key: IdentityKey,
     message: SignalMessage,
@@ -248,16 +249,16 @@ impl PreKeySignalMessage {
     pub fn new(
         message_version: u8,
         registration_id: u32,
-        pre_key_id: Option<u32>,
-        signed_pre_key_id: u32,
+        pre_key_id: Option<PreKeyId>,
+        signed_pre_key_id: SignedPreKeyId,
         base_key: PublicKey,
         identity_key: IdentityKey,
         message: SignalMessage,
     ) -> Result<Self> {
         let proto_message = proto::wire::PreKeySignalMessage {
             registration_id: Some(registration_id),
-            pre_key_id,
-            signed_pre_key_id: Some(signed_pre_key_id),
+            pre_key_id: pre_key_id.map(|id| id.into()),
+            signed_pre_key_id: Some(signed_pre_key_id.into()),
             base_key: Some(base_key.serialize().into_vec()),
             identity_key: Some(identity_key.serialize().into_vec()),
             message: Some(Vec::from(message.as_ref())),
@@ -291,12 +292,12 @@ impl PreKeySignalMessage {
     }
 
     #[inline]
-    pub fn pre_key_id(&self) -> Option<u32> {
+    pub fn pre_key_id(&self) -> Option<PreKeyId> {
         self.pre_key_id
     }
 
     #[inline]
-    pub fn signed_pre_key_id(&self) -> u32 {
+    pub fn signed_pre_key_id(&self) -> SignedPreKeyId {
         self.signed_pre_key_id
     }
 
@@ -368,8 +369,8 @@ impl TryFrom<&[u8]> for PreKeySignalMessage {
         Ok(PreKeySignalMessage {
             message_version,
             registration_id: proto_structure.registration_id.unwrap_or(0),
-            pre_key_id: proto_structure.pre_key_id,
-            signed_pre_key_id,
+            pre_key_id: proto_structure.pre_key_id.map(|id| id.into()),
+            signed_pre_key_id: signed_pre_key_id.into(),
             base_key,
             identity_key: IdentityKey::try_from(identity_key.as_ref())?,
             message: SignalMessage::try_from(message.as_ref())?,
@@ -906,7 +907,7 @@ mod tests {
             3,
             365,
             None,
-            97,
+            97.into(),
             base_key_pair.public_key,
             identity_key_pair.public_key.into(),
             message,
@@ -1016,7 +1017,7 @@ mod tests {
             3,
             365,
             None,
-            97,
+            97.into(),
             base_key_pair.public_key,
             identity_key_pair.public_key.into(),
             message,

--- a/rust/protocol/src/session.rs
+++ b/rust/protocol/src/session.rs
@@ -1,16 +1,16 @@
 //
-// Copyright 2020 Signal Messenger, LLC.
+// Copyright 2020-2022 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
 use crate::{
-    Context, Direction, IdentityKeyStore, KeyPair, PreKeyBundle, PreKeySignalMessage, PreKeyStore,
-    ProtocolAddress, Result, SessionRecord, SessionStore, SignalProtocolError, SignedPreKeyStore,
+    Context, Direction, IdentityKeyStore, KeyPair, PreKeyBundle, PreKeyId, PreKeySignalMessage,
+    PreKeyStore, ProtocolAddress, Result, SessionRecord, SessionStore, SignalProtocolError,
+    SignedPreKeyStore,
 };
 
 use crate::ratchet;
 use crate::ratchet::{AliceSignalProtocolParameters, BobSignalProtocolParameters};
-use crate::state::PreKeyId;
 use rand::{CryptoRng, Rng};
 
 /*
@@ -178,7 +178,7 @@ pub async fn process_prekey_bundle<R: Rng + CryptoRng>(
     log::info!(
         "set_unacknowledged_pre_key_message for: {} with preKeyId: {}",
         remote_address,
-        their_one_time_prekey_id.map_or_else(|| "<none>".to_string(), |id| id.to_string())
+        their_one_time_prekey_id.map_or_else(|| "<none>".to_string(), |id| format!("{}", id))
     );
 
     session.set_unacknowledged_pre_key_message(

--- a/rust/protocol/src/session_cipher.rs
+++ b/rust/protocol/src/session_cipher.rs
@@ -1,5 +1,5 @@
 //
-// Copyright 2020-2021 Signal Messenger, LLC.
+// Copyright 2020-2022 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 

--- a/rust/protocol/src/state/bundle.rs
+++ b/rust/protocol/src/state/bundle.rs
@@ -4,12 +4,12 @@
 //
 
 use crate::state::{PreKeyId, SignedPreKeyId};
-use crate::{IdentityKey, PublicKey, Result};
+use crate::{DeviceId, IdentityKey, PublicKey, Result};
 
 #[derive(Debug, Clone)]
 pub struct PreKeyBundle {
     registration_id: u32,
-    device_id: u32,
+    device_id: DeviceId,
     pre_key_id: Option<PreKeyId>,
     pre_key_public: Option<PublicKey>,
     signed_pre_key_id: SignedPreKeyId,
@@ -21,7 +21,7 @@ pub struct PreKeyBundle {
 impl PreKeyBundle {
     pub fn new(
         registration_id: u32,
-        device_id: u32,
+        device_id: DeviceId,
         pre_key: Option<(PreKeyId, PublicKey)>,
         signed_pre_key_id: SignedPreKeyId,
         signed_pre_key_public: PublicKey,
@@ -49,7 +49,7 @@ impl PreKeyBundle {
         Ok(self.registration_id)
     }
 
-    pub fn device_id(&self) -> Result<u32> {
+    pub fn device_id(&self) -> Result<DeviceId> {
         Ok(self.device_id)
     }
 

--- a/rust/protocol/src/state/prekey.rs
+++ b/rust/protocol/src/state/prekey.rs
@@ -1,13 +1,36 @@
 //
-// Copyright 2020 Signal Messenger, LLC.
+// Copyright 2020-2022 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
 use crate::proto::storage::PreKeyRecordStructure;
 use crate::{KeyPair, PrivateKey, PublicKey, Result, SignalProtocolError};
+
 use prost::Message;
 
-pub type PreKeyId = u32;
+use std::fmt;
+
+/// A unique identifier selecting among this client's known pre-keys.
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
+pub struct PreKeyId(u32);
+
+impl From<u32> for PreKeyId {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<PreKeyId> for u32 {
+    fn from(value: PreKeyId) -> Self {
+        value.0
+    }
+}
+
+impl fmt::Display for PreKeyId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct PreKeyRecord {
@@ -20,7 +43,7 @@ impl PreKeyRecord {
         let private_key = key.private_key.serialize().to_vec();
         Self {
             pre_key: PreKeyRecordStructure {
-                id,
+                id: id.into(),
                 public_key,
                 private_key,
             },
@@ -35,7 +58,7 @@ impl PreKeyRecord {
     }
 
     pub fn id(&self) -> Result<PreKeyId> {
-        Ok(self.pre_key.id)
+        Ok(self.pre_key.id.into())
     }
 
     pub fn key_pair(&self) -> Result<KeyPair> {

--- a/rust/protocol/src/state/session.rs
+++ b/rust/protocol/src/state/session.rs
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Signal Messenger, LLC.
+// Copyright 2020-2022 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
@@ -401,8 +401,9 @@ impl SessionState {
         signed_pre_key_id: SignedPreKeyId,
         base_key: &PublicKey,
     ) {
+        let signed_pre_key_id: u32 = signed_pre_key_id.into();
         let pending = session_structure::PendingPreKey {
-            pre_key_id: pre_key_id.unwrap_or(0),
+            pre_key_id: pre_key_id.map(PreKeyId::into).unwrap_or(0),
             signed_pre_key_id: signed_pre_key_id as i32,
             base_key: base_key.serialize().to_vec(),
         };
@@ -416,9 +417,9 @@ impl SessionState {
             Ok(Some(UnacknowledgedPreKeyMessageItems::new(
                 match pending_pre_key.pre_key_id {
                     0 => None,
-                    v => Some(v),
+                    v => Some(v.into()),
                 },
-                pending_pre_key.signed_pre_key_id as SignedPreKeyId,
+                (pending_pre_key.signed_pre_key_id as u32).into(),
                 PublicKey::deserialize(&pending_pre_key.base_key)
                     .map_err(|_| InvalidSessionError("invalid pending PreKey message base key"))?,
             )))

--- a/rust/protocol/src/state/signed_prekey.rs
+++ b/rust/protocol/src/state/signed_prekey.rs
@@ -1,13 +1,36 @@
 //
-// Copyright 2020 Signal Messenger, LLC.
+// Copyright 2020-2022 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
 use crate::proto::storage::SignedPreKeyRecordStructure;
 use crate::{KeyPair, PrivateKey, PublicKey, Result, SignalProtocolError};
+
 use prost::Message;
 
-pub type SignedPreKeyId = u32;
+use std::fmt;
+
+/// A unique identifier selecting among this client's known signed pre-keys.
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
+pub struct SignedPreKeyId(u32);
+
+impl From<u32> for SignedPreKeyId {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<SignedPreKeyId> for u32 {
+    fn from(value: SignedPreKeyId) -> Self {
+        value.0
+    }
+}
+
+impl fmt::Display for SignedPreKeyId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct SignedPreKeyRecord {
@@ -21,7 +44,7 @@ impl SignedPreKeyRecord {
         let signature = signature.to_vec();
         Self {
             signed_pre_key: SignedPreKeyRecordStructure {
-                id,
+                id: id.into(),
                 timestamp,
                 public_key,
                 private_key,
@@ -38,7 +61,7 @@ impl SignedPreKeyRecord {
     }
 
     pub fn id(&self) -> Result<SignedPreKeyId> {
-        Ok(self.signed_pre_key.id)
+        Ok(self.signed_pre_key.id.into())
     }
 
     pub fn timestamp(&self) -> Result<u64> {

--- a/rust/protocol/src/storage/inmem.rs
+++ b/rust/protocol/src/storage/inmem.rs
@@ -4,11 +4,10 @@
 //
 
 use crate::{
-    IdentityKey, IdentityKeyPair, PreKeyRecord, ProtocolAddress, Result, SenderKeyRecord,
-    SessionRecord, SignalProtocolError, SignedPreKeyRecord,
+    IdentityKey, IdentityKeyPair, PreKeyId, PreKeyRecord, ProtocolAddress, Result, SenderKeyRecord,
+    SessionRecord, SignalProtocolError, SignedPreKeyId, SignedPreKeyRecord,
 };
 
-use crate::state::{PreKeyId, SignedPreKeyId};
 use crate::storage::traits;
 use crate::storage::Context;
 

--- a/rust/protocol/tests/groups.rs
+++ b/rust/protocol/tests/groups.rs
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Signal Messenger, LLC.
+// Copyright 2020-2022 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
@@ -19,7 +19,7 @@ use uuid::Uuid;
 fn group_no_send_session() -> Result<(), SignalProtocolError> {
     let mut csprng = OsRng;
 
-    let sender_address = ProtocolAddress::new("+14159999111".to_owned(), 1);
+    let sender_address = ProtocolAddress::new("+14159999111".to_owned(), 1.into());
     let distribution_id = Uuid::from_u128(0xd1d1d1d1_7000_11eb_b32a_33b8a8a487a6);
 
     let mut alice_store = test_in_memory_protocol_store()?;
@@ -86,7 +86,7 @@ fn group_using_context_arg() -> Result<(), SignalProtocolError> {
     async {
         let mut csprng = OsRng;
 
-        let sender_address = ProtocolAddress::new("+14159999111".to_owned(), 1);
+        let sender_address = ProtocolAddress::new("+14159999111".to_owned(), 1.into());
         let distribution_id = Uuid::from_u128(0xd1d1d1d1_7000_11eb_b32a_33b8a8a487a6);
 
         let x = Box::new(1);
@@ -115,7 +115,8 @@ fn group_no_recv_session() -> Result<(), SignalProtocolError> {
     async {
         let mut csprng = OsRng;
 
-        let sender_address = ProtocolAddress::new("+14159999111".to_owned(), 1);
+        let device_id: DeviceId = 1.into();
+        let sender_address = ProtocolAddress::new("+14159999111".to_owned(), device_id);
         let distribution_id = Uuid::from_u128(0xd1d1d1d1_7000_11eb_b32a_33b8a8a487a6);
 
         let mut alice_store = test_in_memory_protocol_store()?;
@@ -164,7 +165,7 @@ fn group_basic_encrypt_decrypt() -> Result<(), SignalProtocolError> {
     async {
         let mut csprng = OsRng;
 
-        let sender_address = ProtocolAddress::new("+14159999111".to_owned(), 1);
+        let sender_address = ProtocolAddress::new("+14159999111".to_owned(), 1.into());
         let distribution_id = Uuid::from_u128(0xd1d1d1d1_7000_11eb_b32a_33b8a8a487a6);
 
         let mut alice_store = test_in_memory_protocol_store()?;
@@ -224,8 +225,8 @@ fn group_sealed_sender() -> Result<(), SignalProtocolError> {
     async {
         let mut csprng = OsRng;
 
-        let alice_device_id = 23;
-        let bob_device_id = 42;
+        let alice_device_id: DeviceId = 23.into();
+        let bob_device_id: DeviceId = 42.into();
 
         let alice_e164 = "+14151111111".to_owned();
 
@@ -235,7 +236,7 @@ fn group_sealed_sender() -> Result<(), SignalProtocolError> {
 
         let alice_uuid_address = ProtocolAddress::new(alice_uuid.clone(), alice_device_id);
         let bob_uuid_address = ProtocolAddress::new(bob_uuid.clone(), bob_device_id);
-        let carol_uuid_address = ProtocolAddress::new(carol_uuid.clone(), 1);
+        let carol_uuid_address = ProtocolAddress::new(carol_uuid.clone(), 1.into());
 
         let distribution_id = Uuid::from_u128(0xd1d1d1d1_7000_11eb_b32a_33b8a8a487a6);
 
@@ -404,7 +405,7 @@ fn group_large_messages() -> Result<(), SignalProtocolError> {
     async {
         let mut csprng = OsRng;
 
-        let sender_address = ProtocolAddress::new("+14159999111".to_owned(), 1);
+        let sender_address = ProtocolAddress::new("+14159999111".to_owned(), 1.into());
         let distribution_id = Uuid::from_u128(0xd1d1d1d1_7000_11eb_b32a_33b8a8a487a6);
 
         let mut alice_store = test_in_memory_protocol_store()?;
@@ -466,7 +467,7 @@ fn group_basic_ratchet() -> Result<(), SignalProtocolError> {
     async {
         let mut csprng = OsRng;
 
-        let sender_address = ProtocolAddress::new("+14159999111".to_owned(), 1);
+        let sender_address = ProtocolAddress::new("+14159999111".to_owned(), 1.into());
         let distribution_id = Uuid::from_u128(0xd1d1d1d1_7000_11eb_b32a_33b8a8a487a6);
 
         let mut alice_store = test_in_memory_protocol_store()?;
@@ -578,7 +579,7 @@ fn group_late_join() -> Result<(), SignalProtocolError> {
     async {
         let mut csprng = OsRng;
 
-        let sender_address = ProtocolAddress::new("+14159999111".to_owned(), 1);
+        let sender_address = ProtocolAddress::new("+14159999111".to_owned(), 1.into());
         let distribution_id = Uuid::from_u128(0xd1d1d1d1_7000_11eb_b32a_33b8a8a487a6);
 
         let mut alice_store = test_in_memory_protocol_store()?;
@@ -650,7 +651,7 @@ fn group_out_of_order() -> Result<(), SignalProtocolError> {
     async {
         let mut csprng = OsRng;
 
-        let sender_address = ProtocolAddress::new("+14159999111".to_owned(), 1);
+        let sender_address = ProtocolAddress::new("+14159999111".to_owned(), 1.into());
         let distribution_id = Uuid::from_u128(0xd1d1d1d1_7000_11eb_b32a_33b8a8a487a6);
 
         let mut alice_store = test_in_memory_protocol_store()?;
@@ -729,7 +730,7 @@ fn group_too_far_in_the_future() -> Result<(), SignalProtocolError> {
     async {
         let mut csprng = OsRng;
 
-        let sender_address = ProtocolAddress::new("+14159999111".to_owned(), 1);
+        let sender_address = ProtocolAddress::new("+14159999111".to_owned(), 1.into());
         let distribution_id = Uuid::from_u128(0xd1d1d1d1_7000_11eb_b32a_33b8a8a487a6);
 
         let mut alice_store = test_in_memory_protocol_store()?;
@@ -797,7 +798,7 @@ fn group_message_key_limit() -> Result<(), SignalProtocolError> {
     async {
         let mut csprng = OsRng;
 
-        let sender_address = ProtocolAddress::new("+14159999111".to_owned(), 1);
+        let sender_address = ProtocolAddress::new("+14159999111".to_owned(), 1.into());
         let distribution_id = Uuid::from_u128(0xd1d1d1d1_7000_11eb_b32a_33b8a8a487a6);
 
         let mut alice_store = test_in_memory_protocol_store()?;

--- a/rust/protocol/tests/sealed_sender.rs
+++ b/rust/protocol/tests/sealed_sender.rs
@@ -88,7 +88,7 @@ fn test_sender_cert() -> Result<(), SignalProtocolError> {
     let server_cert =
         ServerCertificate::new(1, server_key.public_key, &trust_root.private_key, &mut rng)?;
 
-    let device_id = 42;
+    let device_id: DeviceId = 42.into();
     let expires = 1605722925;
 
     let sender_cert = SenderCertificate::new(
@@ -137,8 +137,8 @@ fn test_sealed_sender() -> Result<(), SignalProtocolError> {
     async {
         let mut rng = OsRng;
 
-        let alice_device_id = 23;
-        let bob_device_id = 42;
+        let alice_device_id: DeviceId = 23.into();
+        let bob_device_id: DeviceId = 42.into();
 
         let alice_e164 = "+14151111111".to_owned();
         let bob_e164 = "+14151114444".to_owned();
@@ -305,8 +305,8 @@ fn test_sender_key_in_sealed_sender() -> Result<(), SignalProtocolError> {
     async {
         let mut rng = OsRng;
 
-        let alice_device_id = 23;
-        let bob_device_id = 42;
+        let alice_device_id: DeviceId = 23.into();
+        let bob_device_id: DeviceId = 42.into();
 
         let alice_e164 = "+14151111111".to_owned();
 
@@ -315,7 +315,8 @@ fn test_sender_key_in_sealed_sender() -> Result<(), SignalProtocolError> {
 
         let distribution_id = Uuid::from_u128(0xd1d1d1d1_7000_11eb_b32a_33b8a8a487a6);
 
-        let alice_uuid_address = ProtocolAddress::new(alice_uuid.clone(), 1);
+        let device_id: DeviceId = 1.into();
+        let alice_uuid_address = ProtocolAddress::new(alice_uuid.clone(), device_id);
         let bob_uuid_address = ProtocolAddress::new(bob_uuid.clone(), bob_device_id);
 
         let mut alice_store = support::test_in_memory_protocol_store()?;
@@ -430,8 +431,8 @@ fn test_sealed_sender_multi_recipient() -> Result<(), SignalProtocolError> {
     async {
         let mut rng = OsRng;
 
-        let alice_device_id = 23;
-        let bob_device_id = 42;
+        let alice_device_id: DeviceId = 23.into();
+        let bob_device_id: DeviceId = 42.into();
 
         let alice_e164 = "+14151111111".to_owned();
         let bob_e164 = "+14151114444".to_owned();
@@ -664,8 +665,8 @@ fn test_sealed_sender_multi_recipient_encrypt_with_archived_session(
     async {
         let mut rng = OsRng;
 
-        let alice_device_id = 23;
-        let bob_device_id = 42;
+        let alice_device_id: DeviceId = 23.into();
+        let bob_device_id: DeviceId = 42.into();
 
         let alice_e164 = "+14151111111".to_owned();
 
@@ -777,7 +778,7 @@ fn test_sealed_sender_multi_recipient_encrypt_with_bad_registration_id(
         let alice_uuid = "9d0652a3-dcc3-4d11-975f-74d61598733f".to_string();
         let bob_uuid = "796abedb-ca4e-4f18-8803-1fde5b921f9f".to_string();
 
-        let bob_uuid_address = ProtocolAddress::new(bob_uuid.clone(), bob_device_id);
+        let bob_uuid_address = ProtocolAddress::new(bob_uuid.clone(), bob_device_id.into());
 
         let mut alice_store = support::test_in_memory_protocol_store()?;
         let mut bob_store =
@@ -809,7 +810,7 @@ fn test_sealed_sender_multi_recipient_encrypt_with_bad_registration_id(
             alice_uuid.clone(),
             Some(alice_e164.clone()),
             alice_pubkey,
-            alice_device_id,
+            alice_device_id.into(),
             expires,
             server_cert,
             &server_key.private_key,
@@ -865,15 +866,15 @@ fn test_decryption_error_in_sealed_sender() -> Result<(), SignalProtocolError> {
     async {
         let mut rng = OsRng;
 
-        let alice_device_id = 23;
-        let bob_device_id = 42;
+        let alice_device_id: DeviceId = 23.into();
+        let bob_device_id: DeviceId = 42.into();
 
         let alice_e164 = "+14151111111".to_owned();
 
         let alice_uuid = "9d0652a3-dcc3-4d11-975f-74d61598733f".to_string();
         let bob_uuid = "796abedb-ca4e-4f18-8803-1fde5b921f9f".to_string();
 
-        let alice_uuid_address = ProtocolAddress::new(alice_uuid.clone(), 1);
+        let alice_uuid_address = ProtocolAddress::new(alice_uuid.clone(), 1.into());
         let bob_uuid_address = ProtocolAddress::new(bob_uuid.clone(), bob_device_id);
 
         let mut alice_store = support::test_in_memory_protocol_store()?;

--- a/rust/protocol/tests/session.rs
+++ b/rust/protocol/tests/session.rs
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Signal Messenger, LLC.
+// Copyright 2020-2022 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
@@ -17,8 +17,8 @@ fn test_basic_prekey_v3() -> Result<(), SignalProtocolError> {
     async {
         let mut csprng = OsRng;
 
-        let alice_address = ProtocolAddress::new("+14151111111".to_owned(), 1);
-        let bob_address = ProtocolAddress::new("+14151111112".to_owned(), 1);
+        let alice_address = ProtocolAddress::new("+14151111111".to_owned(), 1.into());
+        let bob_address = ProtocolAddress::new("+14151111112".to_owned(), 1.into());
 
         let mut alice_store = support::test_in_memory_protocol_store()?;
         let mut bob_store = support::test_in_memory_protocol_store()?;
@@ -38,9 +38,9 @@ fn test_basic_prekey_v3() -> Result<(), SignalProtocolError> {
 
         let bob_pre_key_bundle = PreKeyBundle::new(
             bob_store.get_local_registration_id(None).await?,
-            1,                                               // device id
-            Some((pre_key_id, bob_pre_key_pair.public_key)), // pre key
-            signed_pre_key_id,                               // signed pre key id
+            1.into(),                                               // device id
+            Some((pre_key_id.into(), bob_pre_key_pair.public_key)), // pre key
+            signed_pre_key_id.into(),                               // signed pre key id
             bob_signed_pre_key_pair.public_key,
             bob_signed_pre_key_signature.to_vec(),
             *bob_store.get_identity_key_pair(None).await?.identity_key(),
@@ -84,16 +84,16 @@ fn test_basic_prekey_v3() -> Result<(), SignalProtocolError> {
 
         bob_store
             .save_pre_key(
-                pre_key_id,
-                &PreKeyRecord::new(pre_key_id, &bob_pre_key_pair),
+                pre_key_id.into(),
+                &PreKeyRecord::new(pre_key_id.into(), &bob_pre_key_pair),
                 None,
             )
             .await?;
         bob_store
             .save_signed_pre_key(
-                signed_pre_key_id,
+                signed_pre_key_id.into(),
                 &SignedPreKeyRecord::new(
-                    signed_pre_key_id,
+                    signed_pre_key_id.into(),
                     /*timestamp*/ 42,
                     &bob_signed_pre_key_pair,
                     &bob_signed_pre_key_signature,
@@ -158,9 +158,9 @@ fn test_basic_prekey_v3() -> Result<(), SignalProtocolError> {
 
         let bob_pre_key_bundle = PreKeyBundle::new(
             bob_store.get_local_registration_id(None).await?,
-            1,                                                   // device id
-            Some((pre_key_id + 1, bob_pre_key_pair.public_key)), // pre key,
-            signed_pre_key_id + 1,
+            1.into(),                                                     // device id
+            Some(((pre_key_id + 1).into(), bob_pre_key_pair.public_key)), // pre key,
+            (signed_pre_key_id + 1).into(),
             bob_signed_pre_key_pair.public_key,
             bob_signed_pre_key_signature.to_vec(),
             *bob_store.get_identity_key_pair(None).await?.identity_key(),
@@ -168,16 +168,16 @@ fn test_basic_prekey_v3() -> Result<(), SignalProtocolError> {
 
         bob_store
             .save_pre_key(
-                pre_key_id + 1,
-                &PreKeyRecord::new(pre_key_id + 1, &bob_pre_key_pair),
+                (pre_key_id + 1).into(),
+                &PreKeyRecord::new((pre_key_id + 1).into(), &bob_pre_key_pair),
                 None,
             )
             .await?;
         bob_store
             .save_signed_pre_key(
-                signed_pre_key_id + 1,
+                (signed_pre_key_id + 1).into(),
                 &SignedPreKeyRecord::new(
-                    signed_pre_key_id + 1,
+                    (signed_pre_key_id + 1).into(),
                     /*timestamp*/ 42,
                     &bob_signed_pre_key_pair,
                     &bob_signed_pre_key_signature,
@@ -227,9 +227,9 @@ fn test_basic_prekey_v3() -> Result<(), SignalProtocolError> {
         // Sign pre-key with wrong key:
         let bob_pre_key_bundle = PreKeyBundle::new(
             bob_store.get_local_registration_id(None).await?,
-            1,                                               // device id
-            Some((pre_key_id, bob_pre_key_pair.public_key)), // pre key
-            signed_pre_key_id,
+            1.into(),                                               // device id
+            Some((pre_key_id.into(), bob_pre_key_pair.public_key)), // pre key
+            signed_pre_key_id.into(),
             bob_signed_pre_key_pair.public_key,
             bob_signed_pre_key_signature.to_vec(),
             *alice_store
@@ -262,8 +262,8 @@ fn chain_jump_over_limit() -> Result<(), SignalProtocolError> {
     async {
         let mut csprng = OsRng;
 
-        let alice_address = ProtocolAddress::new("+14151111111".to_owned(), 1);
-        let bob_address = ProtocolAddress::new("+14151111112".to_owned(), 1);
+        let alice_address = ProtocolAddress::new("+14151111111".to_owned(), 1.into());
+        let bob_address = ProtocolAddress::new("+14151111112".to_owned(), 1.into());
 
         let mut alice_store = support::test_in_memory_protocol_store()?;
         let mut bob_store = support::test_in_memory_protocol_store()?;
@@ -283,9 +283,9 @@ fn chain_jump_over_limit() -> Result<(), SignalProtocolError> {
 
         let bob_pre_key_bundle = PreKeyBundle::new(
             bob_store.get_local_registration_id(None).await?,
-            1,                                               // device id
-            Some((pre_key_id, bob_pre_key_pair.public_key)), // pre key
-            signed_pre_key_id,                               // signed pre key id
+            1.into(),                                               // device id
+            Some((pre_key_id.into(), bob_pre_key_pair.public_key)), // pre key
+            signed_pre_key_id.into(),                               // signed pre key id
             bob_signed_pre_key_pair.public_key,
             bob_signed_pre_key_signature.to_vec(),
             *bob_store.get_identity_key_pair(None).await?.identity_key(),
@@ -303,16 +303,16 @@ fn chain_jump_over_limit() -> Result<(), SignalProtocolError> {
 
         bob_store
             .save_pre_key(
-                pre_key_id,
-                &PreKeyRecord::new(pre_key_id, &bob_pre_key_pair),
+                pre_key_id.into(),
+                &PreKeyRecord::new(pre_key_id.into(), &bob_pre_key_pair),
                 None,
             )
             .await?;
         bob_store
             .save_signed_pre_key(
-                signed_pre_key_id,
+                signed_pre_key_id.into(),
                 &SignedPreKeyRecord::new(
-                    signed_pre_key_id,
+                    signed_pre_key_id.into(),
                     /*timestamp*/ 42,
                     &bob_signed_pre_key_pair,
                     &bob_signed_pre_key_signature,
@@ -351,8 +351,10 @@ fn chain_jump_over_limit_with_self() -> Result<(), SignalProtocolError> {
     async {
         let mut csprng = OsRng;
 
-        let a1_address = ProtocolAddress::new("+14151111111".to_owned(), 1);
-        let a2_address = ProtocolAddress::new("+14151111111".to_owned(), 2);
+        let device_id_1: DeviceId = 1.into();
+        let a1_address = ProtocolAddress::new("+14151111111".to_owned(), device_id_1);
+        let device_id_2: DeviceId = 2.into();
+        let a2_address = ProtocolAddress::new("+14151111111".to_owned(), device_id_2);
 
         let mut a1_store = support::test_in_memory_protocol_store()?;
         let mut a2_store = a1_store.clone(); // same key!
@@ -372,9 +374,9 @@ fn chain_jump_over_limit_with_self() -> Result<(), SignalProtocolError> {
 
         let a2_pre_key_bundle = PreKeyBundle::new(
             a2_store.get_local_registration_id(None).await?,
-            1,                                              // device id
-            Some((pre_key_id, a2_pre_key_pair.public_key)), // pre key
-            signed_pre_key_id,                              // signed pre key id
+            1.into(),                                              // device id
+            Some((pre_key_id.into(), a2_pre_key_pair.public_key)), // pre key
+            signed_pre_key_id.into(),                              // signed pre key id
             a2_signed_pre_key_pair.public_key,
             a2_signed_pre_key_signature.to_vec(),
             *a2_store.get_identity_key_pair(None).await?.identity_key(),
@@ -392,16 +394,16 @@ fn chain_jump_over_limit_with_self() -> Result<(), SignalProtocolError> {
 
         a2_store
             .save_pre_key(
-                pre_key_id,
-                &PreKeyRecord::new(pre_key_id, &a2_pre_key_pair),
+                pre_key_id.into(),
+                &PreKeyRecord::new(pre_key_id.into(), &a2_pre_key_pair),
                 None,
             )
             .await?;
         a2_store
             .save_signed_pre_key(
-                signed_pre_key_id,
+                signed_pre_key_id.into(),
                 &SignedPreKeyRecord::new(
-                    signed_pre_key_id,
+                    signed_pre_key_id.into(),
                     /*timestamp*/ 42,
                     &a2_signed_pre_key_pair,
                     &a2_signed_pre_key_signature,
@@ -445,7 +447,7 @@ fn chain_jump_over_limit_with_self() -> Result<(), SignalProtocolError> {
 #[allow(clippy::eval_order_dependence)]
 fn test_bad_signed_pre_key_signature() -> Result<(), SignalProtocolError> {
     async {
-        let bob_address = ProtocolAddress::new("+14151111112".to_owned(), 1);
+        let bob_address = ProtocolAddress::new("+14151111112".to_owned(), 1.into());
 
         let mut alice_store = support::test_in_memory_protocol_store()?;
         let bob_store = support::test_in_memory_protocol_store()?;
@@ -472,9 +474,9 @@ fn test_bad_signed_pre_key_signature() -> Result<(), SignalProtocolError> {
 
             let bob_pre_key_bundle = PreKeyBundle::new(
                 bob_store.get_local_registration_id(None).await?,
-                1,
-                Some((pre_key_id, bob_pre_key_pair.public_key)),
-                signed_pre_key_id,
+                1.into(),
+                Some((pre_key_id.into(), bob_pre_key_pair.public_key)),
+                signed_pre_key_id.into(),
                 bob_signed_pre_key_pair.public_key,
                 bad_signature,
                 *bob_store.get_identity_key_pair(None).await?.identity_key(),
@@ -496,9 +498,9 @@ fn test_bad_signed_pre_key_signature() -> Result<(), SignalProtocolError> {
 
         let bob_pre_key_bundle = PreKeyBundle::new(
             bob_store.get_local_registration_id(None).await?,
-            1,
-            Some((pre_key_id, bob_pre_key_pair.public_key)),
-            signed_pre_key_id,
+            1.into(),
+            Some((pre_key_id.into(), bob_pre_key_pair.public_key)),
+            signed_pre_key_id.into(),
             bob_signed_pre_key_pair.public_key,
             bob_signed_pre_key_signature,
             *bob_store.get_identity_key_pair(None).await?.identity_key(),
@@ -526,8 +528,8 @@ fn test_bad_signed_pre_key_signature() -> Result<(), SignalProtocolError> {
 #[allow(clippy::eval_order_dependence)]
 fn repeat_bundle_message_v3() -> Result<(), SignalProtocolError> {
     async {
-        let alice_address = ProtocolAddress::new("+14151111111".to_owned(), 1);
-        let bob_address = ProtocolAddress::new("+14151111112".to_owned(), 1);
+        let alice_address = ProtocolAddress::new("+14151111111".to_owned(), 1.into());
+        let bob_address = ProtocolAddress::new("+14151111112".to_owned(), 1.into());
 
         let mut alice_store = support::test_in_memory_protocol_store()?;
         let mut bob_store = support::test_in_memory_protocol_store()?;
@@ -548,9 +550,9 @@ fn repeat_bundle_message_v3() -> Result<(), SignalProtocolError> {
 
         let bob_pre_key_bundle = PreKeyBundle::new(
             bob_store.get_local_registration_id(None).await?,
-            1,                                               // device id
-            Some((pre_key_id, bob_pre_key_pair.public_key)), // pre key
-            signed_pre_key_id,                               // signed pre key id
+            1.into(),                                               // device id
+            Some((pre_key_id.into(), bob_pre_key_pair.public_key)), // pre key
+            signed_pre_key_id.into(),                               // signed pre key id
             bob_signed_pre_key_pair.public_key,
             bob_signed_pre_key_signature.to_vec(),
             *bob_store.get_identity_key_pair(None).await?.identity_key(),
@@ -599,16 +601,16 @@ fn repeat_bundle_message_v3() -> Result<(), SignalProtocolError> {
 
         bob_store
             .save_pre_key(
-                pre_key_id,
-                &PreKeyRecord::new(pre_key_id, &bob_pre_key_pair),
+                pre_key_id.into(),
+                &PreKeyRecord::new(pre_key_id.into(), &bob_pre_key_pair),
                 None,
             )
             .await?;
         bob_store
             .save_signed_pre_key(
-                signed_pre_key_id,
+                signed_pre_key_id.into(),
                 &SignedPreKeyRecord::new(
-                    signed_pre_key_id,
+                    signed_pre_key_id.into(),
                     /*timestamp*/ 42,
                     &bob_signed_pre_key_pair,
                     &bob_signed_pre_key_signature,
@@ -662,8 +664,8 @@ fn bad_message_bundle() -> Result<(), SignalProtocolError> {
     async {
         let mut csprng = OsRng;
 
-        let alice_address = ProtocolAddress::new("+14151111111".to_owned(), 1);
-        let bob_address = ProtocolAddress::new("+14151111112".to_owned(), 1);
+        let alice_address = ProtocolAddress::new("+14151111111".to_owned(), 1.into());
+        let bob_address = ProtocolAddress::new("+14151111112".to_owned(), 1.into());
 
         let mut alice_store = support::test_in_memory_protocol_store()?;
         let mut bob_store = support::test_in_memory_protocol_store()?;
@@ -683,9 +685,9 @@ fn bad_message_bundle() -> Result<(), SignalProtocolError> {
 
         let bob_pre_key_bundle = PreKeyBundle::new(
             bob_store.get_local_registration_id(None).await?,
-            1, // device id
-            Some((pre_key_id, bob_pre_key_pair.public_key)),
-            signed_pre_key_id, // signed pre key id
+            1.into(), // device id
+            Some((pre_key_id.into(), bob_pre_key_pair.public_key)),
+            signed_pre_key_id.into(), // signed pre key id
             bob_signed_pre_key_pair.public_key,
             bob_signed_pre_key_signature.to_vec(),
             *bob_store.get_identity_key_pair(None).await?.identity_key(),
@@ -703,16 +705,16 @@ fn bad_message_bundle() -> Result<(), SignalProtocolError> {
 
         bob_store
             .save_pre_key(
-                pre_key_id,
-                &PreKeyRecord::new(pre_key_id, &bob_pre_key_pair),
+                pre_key_id.into(),
+                &PreKeyRecord::new(pre_key_id.into(), &bob_pre_key_pair),
                 None,
             )
             .await?;
         bob_store
             .save_signed_pre_key(
-                signed_pre_key_id,
+                signed_pre_key_id.into(),
                 &SignedPreKeyRecord::new(
-                    signed_pre_key_id,
+                    signed_pre_key_id.into(),
                     /*timestamp*/ 42,
                     &bob_signed_pre_key_pair,
                     &bob_signed_pre_key_signature,
@@ -736,7 +738,7 @@ fn bad_message_bundle() -> Result<(), SignalProtocolError> {
 
         let original_message = "L'homme est condamné à être libre";
 
-        assert!(bob_store.get_pre_key(pre_key_id, None).await.is_ok());
+        assert!(bob_store.get_pre_key(pre_key_id.into(), None).await.is_ok());
         let outgoing_message = encrypt(&mut alice_store, &bob_address, original_message).await?;
 
         assert_eq!(
@@ -756,7 +758,7 @@ fn bad_message_bundle() -> Result<(), SignalProtocolError> {
         assert!(decrypt(&mut bob_store, &alice_address, &incoming_message)
             .await
             .is_err());
-        assert!(bob_store.get_pre_key(pre_key_id, None).await.is_ok());
+        assert!(bob_store.get_pre_key(pre_key_id.into(), None).await.is_ok());
 
         let incoming_message = CiphertextMessage::PreKeySignalMessage(
             PreKeySignalMessage::try_from(outgoing_message.as_slice())?,
@@ -769,7 +771,10 @@ fn bad_message_bundle() -> Result<(), SignalProtocolError> {
             original_message
         );
         assert!(matches!(
-            bob_store.get_pre_key(pre_key_id, None).await.unwrap_err(),
+            bob_store
+                .get_pre_key(pre_key_id.into(), None)
+                .await
+                .unwrap_err(),
             SignalProtocolError::InvalidPreKeyId
         ));
 
@@ -783,8 +788,8 @@ fn bad_message_bundle() -> Result<(), SignalProtocolError> {
 #[allow(clippy::eval_order_dependence)]
 fn optional_one_time_prekey() -> Result<(), SignalProtocolError> {
     async {
-        let alice_address = ProtocolAddress::new("+14151111111".to_owned(), 1);
-        let bob_address = ProtocolAddress::new("+14151111112".to_owned(), 1);
+        let alice_address = ProtocolAddress::new("+14151111111".to_owned(), 1.into());
+        let bob_address = ProtocolAddress::new("+14151111112".to_owned(), 1.into());
 
         let mut alice_store = support::test_in_memory_protocol_store()?;
         let mut bob_store = support::test_in_memory_protocol_store()?;
@@ -803,9 +808,9 @@ fn optional_one_time_prekey() -> Result<(), SignalProtocolError> {
 
         let bob_pre_key_bundle = PreKeyBundle::new(
             bob_store.get_local_registration_id(None).await?,
-            1,                 // device id
-            None,              // no pre key
-            signed_pre_key_id, // signed pre key id
+            1.into(),                 // device id
+            None,                     // no pre key
+            signed_pre_key_id.into(), // signed pre key id
             bob_signed_pre_key_pair.public_key,
             bob_signed_pre_key_signature.to_vec(),
             *bob_store.get_identity_key_pair(None).await?.identity_key(),
@@ -845,9 +850,9 @@ fn optional_one_time_prekey() -> Result<(), SignalProtocolError> {
 
         bob_store
             .save_signed_pre_key(
-                signed_pre_key_id,
+                signed_pre_key_id.into(),
                 &SignedPreKeyRecord::new(
-                    signed_pre_key_id,
+                    signed_pre_key_id.into(),
                     /*timestamp*/ 42,
                     &bob_signed_pre_key_pair,
                     &bob_signed_pre_key_signature,
@@ -881,8 +886,8 @@ fn message_key_limits() -> Result<(), SignalProtocolError> {
     async {
         let (alice_session_record, bob_session_record) = initialize_sessions_v3()?;
 
-        let alice_address = ProtocolAddress::new("+14159999999".to_owned(), 1);
-        let bob_address = ProtocolAddress::new("+14158888888".to_owned(), 1);
+        let alice_address = ProtocolAddress::new("+14159999999".to_owned(), 1.into());
+        let bob_address = ProtocolAddress::new("+14158888888".to_owned(), 1.into());
 
         let mut alice_store = support::test_in_memory_protocol_store()?;
         let mut bob_store = support::test_in_memory_protocol_store()?;
@@ -943,8 +948,8 @@ fn run_session_interaction(
     async {
         use rand::seq::SliceRandom;
 
-        let alice_address = ProtocolAddress::new("+14159999999".to_owned(), 1);
-        let bob_address = ProtocolAddress::new("+14158888888".to_owned(), 1);
+        let alice_address = ProtocolAddress::new("+14159999999".to_owned(), 1.into());
+        let bob_address = ProtocolAddress::new("+14158888888".to_owned(), 1.into());
 
         let mut alice_store = support::test_in_memory_protocol_store()?;
         let mut bob_store = support::test_in_memory_protocol_store()?;
@@ -1149,8 +1154,8 @@ fn basic_simultaneous_initiate() -> Result<(), SignalProtocolError> {
     async {
         let mut csprng = OsRng;
 
-        let alice_address = ProtocolAddress::new("+14151111111".to_owned(), 1);
-        let bob_address = ProtocolAddress::new("+14151111112".to_owned(), 1);
+        let alice_address = ProtocolAddress::new("+14151111111".to_owned(), 1.into());
+        let bob_address = ProtocolAddress::new("+14151111112".to_owned(), 1.into());
 
         let mut alice_store = support::test_in_memory_protocol_store()?;
         let mut bob_store = support::test_in_memory_protocol_store()?;
@@ -1289,8 +1294,8 @@ fn simultaneous_initiate_with_lossage() -> Result<(), SignalProtocolError> {
     async {
         let mut csprng = OsRng;
 
-        let alice_address = ProtocolAddress::new("+14151111111".to_owned(), 1);
-        let bob_address = ProtocolAddress::new("+14151111112".to_owned(), 1);
+        let alice_address = ProtocolAddress::new("+14151111111".to_owned(), 1.into());
+        let bob_address = ProtocolAddress::new("+14151111112".to_owned(), 1.into());
 
         let mut alice_store = support::test_in_memory_protocol_store()?;
         let mut bob_store = support::test_in_memory_protocol_store()?;
@@ -1411,8 +1416,8 @@ fn simultaneous_initiate_lost_message() -> Result<(), SignalProtocolError> {
     async {
         let mut csprng = OsRng;
 
-        let alice_address = ProtocolAddress::new("+14151111111".to_owned(), 1);
-        let bob_address = ProtocolAddress::new("+14151111112".to_owned(), 1);
+        let alice_address = ProtocolAddress::new("+14151111111".to_owned(), 1.into());
+        let bob_address = ProtocolAddress::new("+14151111112".to_owned(), 1.into());
 
         let mut alice_store = support::test_in_memory_protocol_store()?;
         let mut bob_store = support::test_in_memory_protocol_store()?;
@@ -1542,8 +1547,8 @@ fn simultaneous_initiate_repeated_messages() -> Result<(), SignalProtocolError> 
     async {
         let mut csprng = OsRng;
 
-        let alice_address = ProtocolAddress::new("+14151111111".to_owned(), 1);
-        let bob_address = ProtocolAddress::new("+14151111112".to_owned(), 1);
+        let alice_address = ProtocolAddress::new("+14151111111".to_owned(), 1.into());
+        let bob_address = ProtocolAddress::new("+14151111112".to_owned(), 1.into());
 
         let mut alice_store = support::test_in_memory_protocol_store()?;
         let mut bob_store = support::test_in_memory_protocol_store()?;
@@ -1744,8 +1749,8 @@ fn simultaneous_initiate_lost_message_repeated_messages() -> Result<(), SignalPr
     async {
         let mut csprng = OsRng;
 
-        let alice_address = ProtocolAddress::new("+14151111111".to_owned(), 1);
-        let bob_address = ProtocolAddress::new("+14151111112".to_owned(), 1);
+        let alice_address = ProtocolAddress::new("+14151111111".to_owned(), 1.into());
+        let bob_address = ProtocolAddress::new("+14151111112".to_owned(), 1.into());
 
         let mut alice_store = support::test_in_memory_protocol_store()?;
         let mut bob_store = support::test_in_memory_protocol_store()?;

--- a/rust/protocol/tests/support/mod.rs
+++ b/rust/protocol/tests/support/mod.rs
@@ -71,9 +71,9 @@ pub async fn create_pre_key_bundle<R: Rng + CryptoRng>(
 
     let pre_key_bundle = PreKeyBundle::new(
         store.get_local_registration_id(None).await?,
-        device_id,
-        Some((pre_key_id, pre_key_pair.public_key)),
-        signed_pre_key_id,
+        device_id.into(),
+        Some((pre_key_id.into(), pre_key_pair.public_key)),
+        signed_pre_key_id.into(),
         signed_pre_key_pair.public_key,
         signed_pre_key_signature.to_vec(),
         *store.get_identity_key_pair(None).await?.identity_key(),
@@ -81,8 +81,8 @@ pub async fn create_pre_key_bundle<R: Rng + CryptoRng>(
 
     store
         .save_pre_key(
-            pre_key_id,
-            &PreKeyRecord::new(pre_key_id, &pre_key_pair),
+            pre_key_id.into(),
+            &PreKeyRecord::new(pre_key_id.into(), &pre_key_pair),
             None,
         )
         .await?;
@@ -91,9 +91,9 @@ pub async fn create_pre_key_bundle<R: Rng + CryptoRng>(
 
     store
         .save_signed_pre_key(
-            signed_pre_key_id,
+            signed_pre_key_id.into(),
             &SignedPreKeyRecord::new(
-                signed_pre_key_id,
+                signed_pre_key_id.into(),
                 timestamp,
                 &signed_pre_key_pair,
                 &signed_pre_key_signature,


### PR DESCRIPTION
### Problem
See https://github.com/signalapp/libsignal-client/pull/286/files#r625970592 from #286 for motivation. We currently use `u32` to mean different things in different places, including in the `.device_id()` method of `address::ProtocolAddress`. We would prefer instead to require an explicit `.into()` from an intermediate struct that looks like:
```rust
#[derive(Copy, Clone)]
pub struct DeviceId(u32);
impl From<u32> for DeviceId { ... }
impl From<DeviceId> for u32 { ... }
```

So note that this is *not* part of the documentation push in #285, but rather a separate type of refactoring change.

### Solution
(all of the below also have docstrings)
1. Create `address::DeviceId` wrapping `u32`.
1. Modify the existing definition of `storage::prekey::PreKeyId` wrapping `u32`.
1. Modify the existing definition of `storage::signed_prekey::SignedPreKeyId` wrapping `u32`.
1. Apply `.into()` calls to convert to and from `u32` as necessary to make tests pass.

### Result
We don't accidentally mistake a device id for a chain counter!