### PR TITLE
Node: make sealedSenderDecryptToUsmc synchronous

### DIFF
--- a/java/java/src/main/java/org/signal/internal/Native.java
+++ b/java/java/src/main/java/org/signal/internal/Native.java
@@ -176,7 +176,7 @@ public final class Native {
 
   public static native boolean ScannableFingerprint_Compare(byte[] fprint1, byte[] fprint2);
 
-  public static native long SealedSessionCipher_DecryptToUsmc(byte[] ctext, IdentityKeyStore identityStore, Object ctx);
+  public static native long SealedSessionCipher_DecryptToUsmc(byte[] ctext, long identityPrivate, long identityPublic);
   public static native byte[] SealedSessionCipher_Encrypt(long destination, long content, IdentityKeyStore identityKeyStore, Object ctx);
   public static native byte[] SealedSessionCipher_MultiRecipientEncrypt(long[] recipients, long content, IdentityKeyStore identityKeyStore, Object ctx);
   public static native byte[] SealedSessionCipher_MultiRecipientMessageForSingleRecipient(byte[] encodedMultiRecipientMessage);

--- a/java/java/src/main/java/org/signal/libsignal/metadata/SealedSessionCipher.java
+++ b/java/java/src/main/java/org/signal/libsignal/metadata/SealedSessionCipher.java
@@ -106,10 +106,14 @@ public class SealedSessionCipher {
       ProtocolInvalidKeyIdException, ProtocolUntrustedIdentityException,
       SelfSendException
   {
+    IdentityKeyPair identity = this.signalProtocolStore.getIdentityKeyPair();
     UnidentifiedSenderMessageContent content;
     try {
       content = new UnidentifiedSenderMessageContent(
-        Native.SealedSessionCipher_DecryptToUsmc(ciphertext, this.signalProtocolStore, null));
+        Native.SealedSessionCipher_DecryptToUsmc(
+          ciphertext,
+          identity.getPrivateKey().nativeHandle(),
+          identity.getPublicKey().nativeHandle()));
       validator.validate(content.getSenderCertificate(), timestamp);
     } catch (Exception e) {
       throw new InvalidMetadataMessageException(e);

--- a/node/Native.d.ts
+++ b/node/Native.d.ts
@@ -97,7 +97,7 @@ export function SealedSenderDecryptionResult_GetSenderE164(obj: Wrapper<SealedSe
 export function SealedSenderDecryptionResult_GetSenderUuid(obj: Wrapper<SealedSenderDecryptionResult>): string;
 export function SealedSenderDecryptionResult_Message(obj: Wrapper<SealedSenderDecryptionResult>): Buffer;
 export function SealedSender_DecryptMessage(message: Buffer, trustRoot: Wrapper<PublicKey>, timestamp: number, localE164: string | null, localUuid: string, localDeviceId: number, sessionStore: SessionStore, identityStore: IdentityKeyStore, prekeyStore: PreKeyStore, signedPrekeyStore: SignedPreKeyStore): Promise<SealedSenderDecryptionResult>;
-export function SealedSender_DecryptToUsmc(ctext: Buffer, identityStore: IdentityKeyStore, ctx: null): Promise<UnidentifiedSenderMessageContent>;
+export function SealedSender_DecryptToUsmc(ctext: Buffer, identityPrivate: Wrapper<PrivateKey>, identityPublic: Wrapper<PublicKey>): UnidentifiedSenderMessageContent;
 export function SealedSender_Encrypt(destination: Wrapper<ProtocolAddress>, content: Wrapper<UnidentifiedSenderMessageContent>, identityKeyStore: IdentityKeyStore, ctx: null): Promise<Buffer>;
 export function SealedSender_MultiRecipientEncrypt(recipients: Wrapper<ProtocolAddress>[], content: Wrapper<UnidentifiedSenderMessageContent>, identityKeyStore: IdentityKeyStore, ctx: null): Promise<Buffer>;
 export function SealedSender_MultiRecipientMessageForSingleRecipient(encodedMultiRecipientMessage: Buffer): Buffer;

--- a/node/index.ts
+++ b/node/index.ts
@@ -1012,7 +1012,7 @@ export abstract class SessionStore implements Native.SessionStore {
 
 export abstract class IdentityKeyStore implements Native.IdentityKeyStore {
   async _getIdentityKey(): Promise<Native.PrivateKey> {
-    const key = await this.getIdentityKey();
+    const key = this.getIdentityKey();
     return key._nativeHandle;
   }
 
@@ -1052,8 +1052,8 @@ export abstract class IdentityKeyStore implements Native.IdentityKeyStore {
     }
   }
 
-  abstract getIdentityKey(): Promise<PrivateKey>;
-  abstract getLocalRegistrationId(): Promise<number>;
+  abstract getIdentityKey(): PrivateKey;
+  abstract getLocalRegistrationId(): number;
   abstract saveIdentity(
     name: ProtocolAddress,
     key: PublicKey
@@ -1365,14 +1365,15 @@ export async function sealedSenderDecryptMessage(
   return SealedSenderDecryptionResult._fromNativeHandle(ssdr);
 }
 
-export async function sealedSenderDecryptToUsmc(
+export function sealedSenderDecryptToUsmc(
   message: Buffer,
   identityStore: IdentityKeyStore
-): Promise<UnidentifiedSenderMessageContent> {
-  const usmc = await NativeImpl.SealedSender_DecryptToUsmc(
+): UnidentifiedSenderMessageContent {
+  const identity = identityStore.getIdentityKey();
+  const usmc = NativeImpl.SealedSender_DecryptToUsmc(
     message,
-    identityStore,
-    null
+    identity,
+    identity.getPublicKey()
   );
   return UnidentifiedSenderMessageContent._fromNativeHandle(usmc);
 }

--- a/node/test/PublicAPITest.ts
+++ b/node/test/PublicAPITest.ts
@@ -54,11 +54,11 @@ class InMemoryIdentityKeyStore extends SignalClient.IdentityKeyStore {
     this.localRegistrationId = 5;
   }
 
-  async getIdentityKey(): Promise<SignalClient.PrivateKey> {
-    return Promise.resolve(this.identityKey);
+  getIdentityKey(): SignalClient.PrivateKey {
+    return this.identityKey;
   }
-  async getLocalRegistrationId(): Promise<number> {
-    return Promise.resolve(this.localRegistrationId);
+  getLocalRegistrationId(): number {
+    return this.localRegistrationId;
   }
 
   async isTrustedIdentity(

--- a/rust/bridge/shared/src/protocol.rs
+++ b/rust/bridge/shared/src/protocol.rs
@@ -1014,12 +1014,15 @@ fn SealedSender_MultiRecipientMessageForSingleRecipient<E: Env>(
 }
 
 #[bridge_fn(node = "SealedSender_DecryptToUsmc")]
-async fn SealedSessionCipher_DecryptToUsmc(
+fn SealedSessionCipher_DecryptToUsmc(
     ctext: &[u8],
-    identity_store: &mut dyn IdentityKeyStore,
-    ctx: Context,
+    identity_private: &PrivateKey,
+    identity_public: &PublicKey,
 ) -> Result<UnidentifiedSenderMessageContent> {
-    sealed_sender_decrypt_to_usmc(ctext, identity_store, ctx).await
+    sealed_sender_decrypt_to_usmc(
+        ctext,
+        &IdentityKeyPair::new(IdentityKey::new(*identity_public), *identity_private),
+    )
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/rust/protocol/tests/groups.rs
+++ b/rust/protocol/tests/groups.rs
@@ -340,8 +340,10 @@ fn group_sealed_sender() -> Result<(), SignalProtocolError> {
         let [bob_ctext, carol_ctext] =
             <[_; 2]>::try_from(sealed_sender_multi_recipient_fan_out(&alice_ctext)?).unwrap();
 
-        let bob_usmc =
-            sealed_sender_decrypt_to_usmc(&bob_ctext, &mut bob_store.identity_store, None).await?;
+        let bob_usmc = sealed_sender_decrypt_to_usmc(
+            &bob_ctext,
+            &bob_store.identity_store.get_identity_key_pair(None).await?,
+        )?;
 
         assert_eq!(bob_usmc.sender()?.sender_uuid()?, alice_uuid);
         assert_eq!(bob_usmc.sender()?.sender_e164()?, Some(alice_e164.as_ref()));
@@ -362,9 +364,13 @@ fn group_sealed_sender() -> Result<(), SignalProtocolError> {
             "space camp?"
         );
 
-        let carol_usmc =
-            sealed_sender_decrypt_to_usmc(&carol_ctext, &mut carol_store.identity_store, None)
-                .await?;
+        let carol_usmc = sealed_sender_decrypt_to_usmc(
+            &carol_ctext,
+            &carol_store
+                .identity_store
+                .get_identity_key_pair(None)
+                .await?,
+        )?;
 
         assert_eq!(carol_usmc.serialized()?, bob_usmc.serialized()?);
 

--- a/rust/protocol/tests/sealed_sender.rs
+++ b/rust/protocol/tests/sealed_sender.rs
@@ -400,9 +400,10 @@ fn test_sender_key_in_sealed_sender() -> Result<(), SignalProtocolError> {
         )
         .await?;
 
-        let bob_usmc =
-            sealed_sender_decrypt_to_usmc(&alice_ctext, &mut bob_store.identity_store, None)
-                .await?;
+        let bob_usmc = sealed_sender_decrypt_to_usmc(
+            &alice_ctext,
+            &bob_store.identity_store.get_identity_key_pair(None).await?,
+        )?;
 
         assert!(matches!(
             bob_usmc.msg_type()?,

--- a/swift/Sources/SignalFfi/signal_ffi.h
+++ b/swift/Sources/SignalFfi/signal_ffi.h
@@ -911,8 +911,8 @@ SignalFfiError *signal_sealed_sender_multi_recipient_message_for_single_recipien
 SignalFfiError *signal_sealed_session_cipher_decrypt_to_usmc(SignalUnidentifiedSenderMessageContent **out,
                                                              const unsigned char *ctext,
                                                              size_t ctext_len,
-                                                             const SignalIdentityKeyStore *identity_store,
-                                                             void *ctx);
+                                                             const SignalPrivateKey *identity_private,
+                                                             const SignalPublicKey *identity_public);
 
 SignalFfiError *signal_sender_key_distribution_message_create(SignalSenderKeyDistributionMessage **out,
                                                               const SignalProtocolAddress *sender,


### PR DESCRIPTION
...by requiring `IdentityKeyStore.getIdentityKey` and `getLocalRegistrationId` to be synchronous.

Because of the way libsignal-client is built, this change propagates to the other platforms' implementations, but the interface doesn't change there.

In theory we could implement this at the Rust level by having a "synchronous IdentityKeyStore trait" and the regular IdentityKeyStore trait inherit from it, but that's a lot of trouble for the single accessor `sealed_sender_decrypt_to_usmc` was using unconditionally.