### PR TITLE
Bulk fetch identity keys for Sealed Sender v2

### DIFF
--- a/java/java/src/main/java/org/signal/internal/Native.java
+++ b/java/java/src/main/java/org/signal/internal/Native.java
@@ -194,7 +194,7 @@ public final class Native {
 
   public static native long SealedSessionCipher_DecryptToUsmc(byte[] ctext, IdentityKeyStore identityStore, Object ctx);
   public static native byte[] SealedSessionCipher_Encrypt(long destination, long content, IdentityKeyStore identityKeyStore, Object ctx);
-  public static native byte[] SealedSessionCipher_MultiRecipientEncrypt(long[] recipients, long[] recipientSessions, long content, IdentityKeyStore identityKeyStore, Object ctx);
+  public static native byte[] SealedSessionCipher_MultiRecipientEncrypt(long[] recipients, long[] recipientIdentities, long[] recipientSessions, long content, IdentityKeyStore identityKeyStore, Object ctx);
   public static native byte[] SealedSessionCipher_MultiRecipientMessageForSingleRecipient(byte[] encodedMultiRecipientMessage);
 
   public static native long SenderCertificate_Deserialize(byte[] data);

--- a/java/java/src/main/java/org/signal/libsignal/metadata/SealedSessionCipher.java
+++ b/java/java/src/main/java/org/signal/libsignal/metadata/SealedSessionCipher.java
@@ -92,7 +92,7 @@ public class SealedSessionCipher {
     }
 
     List<IdentityKey> recipientIdentities =
-      this.signalProtocolStore.loadIdentities(recipients);
+      this.signalProtocolStore.getIdentities(recipients);
 
     long[] recipientIdentitiesHandles = new long[recipients.size()];
     i = 0;

--- a/java/java/src/main/java/org/signal/libsignal/metadata/SealedSessionCipher.java
+++ b/java/java/src/main/java/org/signal/libsignal/metadata/SealedSessionCipher.java
@@ -94,10 +94,10 @@ public class SealedSessionCipher {
     List<IdentityKey> recipientIdentities =
       this.signalProtocolStore.getIdentities(recipients);
 
-    long[] recipientIdentitiesHandles = new long[recipients.size()];
+    long[] recipientIdentityHandles = new long[recipients.size()];
     i = 0;
     for (IdentityKey nextIdentity : recipientIdentities) {
-      recipientHandles[i] = nextIdentity.nativeHandle();
+      recipientIdentityHandles[i] = nextIdentity.nativeHandle();
       i++;
     }
 
@@ -110,7 +110,7 @@ public class SealedSessionCipher {
 
     return Native.SealedSessionCipher_MultiRecipientEncrypt(
       recipientHandles,
-      recipientIdentities,
+      recipientIdentityHandles,
       recipientSessionHandles,
       content.nativeHandle(),
       this.signalProtocolStore,

--- a/java/java/src/main/java/org/signal/libsignal/metadata/SealedSessionCipher.java
+++ b/java/java/src/main/java/org/signal/libsignal/metadata/SealedSessionCipher.java
@@ -5,7 +5,7 @@ import org.signal.libsignal.metadata.certificate.InvalidCertificateException;
 import org.signal.libsignal.metadata.certificate.SenderCertificate;
 import org.signal.libsignal.metadata.protocol.UnidentifiedSenderMessageContent;
 import org.whispersystems.libsignal.DuplicateMessageException;
-import org.whispersystems.libsignal.IdentityKeyPair;
+import org.whispersystems.libsignal.IdentityKey;
 import org.whispersystems.libsignal.InvalidKeyException;
 import org.whispersystems.libsignal.InvalidKeyIdException;
 import org.whispersystems.libsignal.InvalidMacException;
@@ -91,6 +91,16 @@ public class SealedSessionCipher {
       i++;
     }
 
+    List<IdentityKey> recipientIdentities =
+      this.signalProtocolStore.loadIdentities(recipients);
+
+    long[] recipientIdentitiesHandles = new long[recipients.size()];
+    i = 0;
+    for (IdentityKey nextIdentity : recipientIdentities) {
+      recipientHandles[i] = nextIdentity.nativeHandle();
+      i++;
+    }
+
     long[] recipientHandles = new long[recipients.size()];
     i = 0;
     for (SignalProtocolAddress nextRecipient : recipients) {
@@ -100,6 +110,7 @@ public class SealedSessionCipher {
 
     return Native.SealedSessionCipher_MultiRecipientEncrypt(
       recipientHandles,
+      recipientIdentities,
       recipientSessionHandles,
       content.nativeHandle(),
       this.signalProtocolStore,

--- a/java/java/src/main/java/org/signal/libsignal/metadata/SealedSessionCipher.java
+++ b/java/java/src/main/java/org/signal/libsignal/metadata/SealedSessionCipher.java
@@ -12,6 +12,7 @@ import org.whispersystems.libsignal.InvalidMacException;
 import org.whispersystems.libsignal.InvalidMessageException;
 import org.whispersystems.libsignal.InvalidVersionException;
 import org.whispersystems.libsignal.LegacyMessageException;
+import org.whispersystems.libsignal.NoIdentityException;
 import org.whispersystems.libsignal.NoSessionException;
 import org.whispersystems.libsignal.SessionCipher;
 import org.whispersystems.libsignal.SignalProtocolAddress;
@@ -79,7 +80,7 @@ public class SealedSessionCipher {
   }
 
   public byte[] multiRecipientEncrypt(List<SignalProtocolAddress> recipients, UnidentifiedSenderMessageContent content)
-      throws InvalidKeyException, NoSessionException, UntrustedIdentityException
+      throws InvalidKeyException, NoSessionException, NoIdentityException, UntrustedIdentityException
   {
     List<SessionRecord> recipientSessions =
       this.signalProtocolStore.loadExistingSessions(recipients);

--- a/java/java/src/main/java/org/whispersystems/libsignal/NoIdentityException.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/NoIdentityException.java
@@ -1,0 +1,12 @@
+/**
+ * Copyright (C) 2021 Open Whisper Systems
+ *
+ * Licensed according to the LICENSE file in this repository.
+ */
+package org.whispersystems.libsignal;
+
+public class NoIdentityException extends Exception {
+  public NoIdentityException(String s) {
+    super(s);
+  }
+}

--- a/java/java/src/main/java/org/whispersystems/libsignal/state/IdentityKeyStore.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/state/IdentityKeyStore.java
@@ -7,7 +7,10 @@ package org.whispersystems.libsignal.state;
 
 import org.whispersystems.libsignal.IdentityKey;
 import org.whispersystems.libsignal.IdentityKeyPair;
+import org.whispersystems.libsignal.NoIdentityException;
 import org.whispersystems.libsignal.SignalProtocolAddress;
+
+import java.util.List;
 
 /**
  * Provides an interface to identity information.
@@ -79,4 +82,12 @@ public interface IdentityKeyStore {
    */
   public IdentityKey getIdentity(SignalProtocolAddress address);
 
+
+  /**
+   * Return the saved public identity key for a remote client
+   *
+   * @param address The address of the remote client
+   * @return The public identity key, or null if absent
+   */
+  public List<IdentityKey> getIdentities(List<SignalProtocolAddress> addresses) throws NoIdentityException;
 }

--- a/java/java/src/main/java/org/whispersystems/libsignal/state/impl/InMemoryIdentityKeyStore.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/state/impl/InMemoryIdentityKeyStore.java
@@ -7,10 +7,13 @@ package org.whispersystems.libsignal.state.impl;
 
 import org.whispersystems.libsignal.IdentityKey;
 import org.whispersystems.libsignal.IdentityKeyPair;
+import org.whispersystems.libsignal.NoIdentityException;
 import org.whispersystems.libsignal.SignalProtocolAddress;
 import org.whispersystems.libsignal.state.IdentityKeyStore;
 
 import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 
 public class InMemoryIdentityKeyStore implements IdentityKeyStore {
@@ -56,5 +59,18 @@ public class InMemoryIdentityKeyStore implements IdentityKeyStore {
   @Override
   public IdentityKey getIdentity(SignalProtocolAddress address) {
     return trustedKeys.get(address);
+  }
+
+  @Override
+  public synchronized List<IdentityKey> getIdentities(List<SignalProtocolAddress> addresses) throws NoIdentityException {
+    List<IdentityKey> resultKeys = new LinkedList<>();
+    for (SignalProtocolAddress remoteAddress : addresses) {
+      IdentityKey key = trustedKeys.get(remoteAddress);
+      if (key == null) {
+        throw new NoIdentityException("no identity for " + remoteAddress);
+      }
+      resultKeys.add(key);
+    }
+    return resultKeys;
   }
 }

--- a/java/java/src/main/java/org/whispersystems/libsignal/state/impl/InMemorySignalProtocolStore.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/state/impl/InMemorySignalProtocolStore.java
@@ -9,6 +9,7 @@ import org.whispersystems.libsignal.SignalProtocolAddress;
 import org.whispersystems.libsignal.IdentityKey;
 import org.whispersystems.libsignal.IdentityKeyPair;
 import org.whispersystems.libsignal.InvalidKeyIdException;
+import org.whispersystems.libsignal.NoIdentityException;
 import org.whispersystems.libsignal.NoSessionException;
 import org.whispersystems.libsignal.groups.state.InMemorySenderKeyStore;
 import org.whispersystems.libsignal.groups.state.SenderKeyRecord;
@@ -59,7 +60,7 @@ public class InMemorySignalProtocolStore implements SignalProtocolStore {
   }
 
   @Override
-  public List<IdentityKey> getIdentities(List<SignalProtocolAddress> addresses) {
+  public List<IdentityKey> getIdentities(List<SignalProtocolAddress> addresses) throws NoIdentityException {
     return identityKeyStore.getIdentities(addresses);
   }
 

--- a/java/java/src/main/java/org/whispersystems/libsignal/state/impl/InMemorySignalProtocolStore.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/state/impl/InMemorySignalProtocolStore.java
@@ -60,7 +60,7 @@ public class InMemorySignalProtocolStore implements SignalProtocolStore {
 
   @Override
   public List<IdentityKey> getIdentities(List<SignalProtocolAddress> addresses) {
-    return identityKeyStore.getIdentities(address);
+    return identityKeyStore.getIdentities(addresses);
   }
 
   @Override

--- a/java/java/src/main/java/org/whispersystems/libsignal/state/impl/InMemorySignalProtocolStore.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/state/impl/InMemorySignalProtocolStore.java
@@ -59,6 +59,11 @@ public class InMemorySignalProtocolStore implements SignalProtocolStore {
   }
 
   @Override
+  public List<IdentityKey> getIdentities(List<SignalProtocolAddress> addresses) {
+    return identityKeyStore.getIdentities(address);
+  }
+
+  @Override
   public PreKeyRecord loadPreKey(int preKeyId) throws InvalidKeyIdException {
     return preKeyStore.loadPreKey(preKeyId);
   }

--- a/java/tests/src/test/java/org/signal/libsignal/metadata/SealedSessionCipherTest.java
+++ b/java/tests/src/test/java/org/signal/libsignal/metadata/SealedSessionCipherTest.java
@@ -12,6 +12,7 @@ import org.whispersystems.libsignal.IdentityKeyPair;
 import org.whispersystems.libsignal.InvalidKeyException;
 import org.whispersystems.libsignal.InvalidMessageException;
 import org.whispersystems.libsignal.LegacyMessageException;
+import org.whispersystems.libsignal.NoIdentityException;
 import org.whispersystems.libsignal.NoSessionException;
 import org.whispersystems.libsignal.SessionBuilder;
 import org.whispersystems.libsignal.SessionCipher;
@@ -146,7 +147,7 @@ public class SealedSessionCipherTest extends TestCase {
     }
   }
 
-  public void testEncryptDecryptGroup() throws UntrustedIdentityException, InvalidKeyException, InvalidCertificateException, InvalidMessageException, InvalidMetadataMessageException, LegacyMessageException, NoSessionException, ProtocolDuplicateMessageException, ProtocolUntrustedIdentityException, ProtocolLegacyMessageException, ProtocolInvalidKeyException, InvalidMetadataVersionException, ProtocolInvalidVersionException, ProtocolInvalidMessageException, ProtocolInvalidKeyIdException, ProtocolNoSessionException, SelfSendException {
+  public void testEncryptDecryptGroup() throws UntrustedIdentityException, InvalidKeyException, InvalidCertificateException, InvalidMessageException, InvalidMetadataMessageException, LegacyMessageException, NoIdentityException, NoSessionException, ProtocolDuplicateMessageException, ProtocolUntrustedIdentityException, ProtocolLegacyMessageException, ProtocolInvalidKeyException, InvalidMetadataVersionException, ProtocolInvalidVersionException, ProtocolInvalidMessageException, ProtocolInvalidKeyIdException, ProtocolNoSessionException, SelfSendException {
     TestInMemorySignalProtocolStore aliceStore = new TestInMemorySignalProtocolStore();
     TestInMemorySignalProtocolStore bobStore   = new TestInMemorySignalProtocolStore();
     SignalProtocolAddress bobAddress           = new SignalProtocolAddress("e80f7bbe-5b94-471e-bd8c-2173654ea3d1", 1);
@@ -188,7 +189,7 @@ public class SealedSessionCipherTest extends TestCase {
     assertTrue(Arrays.equals(plaintext.getGroupId().get(), new byte[]{42, 43}));
   }
 
-  public void testProtocolException() throws UntrustedIdentityException, InvalidKeyException, InvalidCertificateException, InvalidMessageException, InvalidMetadataMessageException, LegacyMessageException, NoSessionException, ProtocolDuplicateMessageException, ProtocolUntrustedIdentityException, ProtocolLegacyMessageException, ProtocolInvalidKeyException, InvalidMetadataVersionException, ProtocolInvalidVersionException, ProtocolInvalidMessageException, ProtocolInvalidKeyIdException, ProtocolNoSessionException, SelfSendException {
+  public void testProtocolException() throws UntrustedIdentityException, InvalidKeyException, InvalidCertificateException, InvalidMessageException, InvalidMetadataMessageException, LegacyMessageException, NoIdentityException, NoSessionException, ProtocolDuplicateMessageException, ProtocolUntrustedIdentityException, ProtocolLegacyMessageException, ProtocolInvalidKeyException, InvalidMetadataVersionException, ProtocolInvalidVersionException, ProtocolInvalidMessageException, ProtocolInvalidKeyIdException, ProtocolNoSessionException, SelfSendException {
     TestInMemorySignalProtocolStore aliceStore = new TestInMemorySignalProtocolStore();
     TestInMemorySignalProtocolStore bobStore   = new TestInMemorySignalProtocolStore();
     SignalProtocolAddress bobAddress           = new SignalProtocolAddress("e80f7bbe-5b94-471e-bd8c-2173654ea3d1", 1);

--- a/node/Native.d.ts
+++ b/node/Native.d.ts
@@ -111,7 +111,7 @@ export function SealedSenderDecryptionResult_Message(obj: Wrapper<SealedSenderDe
 export function SealedSender_DecryptMessage(message: Buffer, trustRoot: Wrapper<PublicKey>, timestamp: number, localE164: string | null, localUuid: string, localDeviceId: number, sessionStore: SessionStore, identityStore: IdentityKeyStore, prekeyStore: PreKeyStore, signedPrekeyStore: SignedPreKeyStore): Promise<SealedSenderDecryptionResult>;
 export function SealedSender_DecryptToUsmc(ctext: Buffer, identityStore: IdentityKeyStore, ctx: null): Promise<UnidentifiedSenderMessageContent>;
 export function SealedSender_Encrypt(destination: Wrapper<ProtocolAddress>, content: Wrapper<UnidentifiedSenderMessageContent>, identityKeyStore: IdentityKeyStore, ctx: null): Promise<Buffer>;
-export function SealedSender_MultiRecipientEncrypt(recipients: Wrapper<ProtocolAddress>[], recipientSessions: Wrapper<SessionRecord>[], content: Wrapper<UnidentifiedSenderMessageContent>, identityKeyStore: IdentityKeyStore, ctx: null): Promise<Buffer>;
+export function SealedSender_MultiRecipientEncrypt(recipients: Wrapper<ProtocolAddress>[], recipientIdentities: Wrapper<PublicKey>[], recipientSessions: Wrapper<SessionRecord>[], content: Wrapper<UnidentifiedSenderMessageContent>, identityKeyStore: IdentityKeyStore, ctx: null): Promise<Buffer>;
 export function SealedSender_MultiRecipientMessageForSingleRecipient(encodedMultiRecipientMessage: Buffer): Buffer;
 export function SenderCertificate_Deserialize(buffer: Buffer): SenderCertificate;
 export function SenderCertificate_GetCertificate(obj: Wrapper<SenderCertificate>): Buffer;

--- a/node/index.ts
+++ b/node/index.ts
@@ -1063,13 +1063,15 @@ export abstract class IdentityKeyStore implements Native.IdentityKeyStore {
   async getIdentities(
     names: ReadonlyArray<ProtocolAddress>
   ): Promise<Array<PublicKey>> {
-    return Promise.all(names.map(async (name) => {
-      const key = await this.getIdentity(name);
-      if (!key) {
-        throw new Error('Identity not found for: ' + name);
-      }
-      return key;
-    }));
+    return Promise.all(
+      names.map(async name => {
+        const key = await this.getIdentity(name);
+        if (!key) {
+          throw new Error('Identity not found for: ' + name);
+        }
+        return key;
+      })
+    );
   }
 
   abstract getIdentityKey(): Promise<PrivateKey>;
@@ -1447,10 +1449,7 @@ export async function sealedSenderMultiRecipientEncrypt(
   identityStore: IdentityKeyStore,
   sessionStore: SessionStore
 ): Promise<Buffer> {
-  const [
-    recipientSessions,
-    recipientIdentities,
-  ] = await Promise.all([
+  const [recipientSessions, recipientIdentities] = await Promise.all([
     sessionStore.getExistingSessions(recipients),
     identityStore.getIdentities(recipients),
   ]);

--- a/rust/bridge/ffi/src/util.rs
+++ b/rust/bridge/ffi/src/util.rs
@@ -149,6 +149,10 @@ impl From<&SignalFfiError> for SignalErrorCode {
                 SignalErrorCode::UntrustedIdentity
             }
 
+            SignalFfiError::Signal(SignalProtocolError::IdentityNotFound(_)) => {
+                SignalErrorCode::IdentityNotFound
+            }
+
             SignalFfiError::Signal(SignalProtocolError::InvalidState(_, _))
             | SignalFfiError::Signal(SignalProtocolError::NoSenderKeyState)
             | SignalFfiError::Signal(SignalProtocolError::InvalidSessionStructure) => {

--- a/rust/bridge/ffi/src/util.rs
+++ b/rust/bridge/ffi/src/util.rs
@@ -40,6 +40,7 @@ pub enum SignalErrorCode {
     FingerprintParsingError = 52,
 
     UntrustedIdentity = 60,
+    IdentityNotFound = 61,
 
     InvalidKeyIdentifier = 70,
 

--- a/rust/bridge/shared/src/jni/mod.rs
+++ b/rust/bridge/shared/src/jni/mod.rs
@@ -230,6 +230,10 @@ fn throw_error(env: &JNIEnv, error: SignalJniError) {
             "org/whispersystems/libsignal/NoSessionException"
         }
 
+        SignalJniError::Signal(SignalProtocolError::IdentityNotFound(_)) => {
+            "org/whispersystems/libsignal/NoIdentityException"
+        }
+
         SignalJniError::Signal(SignalProtocolError::InvalidMessage(_))
         | SignalJniError::Signal(SignalProtocolError::CiphertextMessageTooShort(_))
         | SignalJniError::Signal(SignalProtocolError::InvalidCiphertext)

--- a/rust/bridge/shared/src/protocol.rs
+++ b/rust/bridge/shared/src/protocol.rs
@@ -1068,18 +1068,20 @@ async fn SealedSessionCipher_Encrypt<E: Env>(
 async fn SealedSender_MultiRecipientEncrypt<E: Env>(
     env: E,
     recipients: &[&ProtocolAddress],
+    recipient_identities: &[&PublicKey],
     recipient_sessions: &[&SessionRecord],
     content: &UnidentifiedSenderMessageContent,
     identity_key_store: &mut dyn IdentityKeyStore,
     ctx: Context,
 ) -> Result<E::Buffer> {
     let mut rng = rand::rngs::OsRng;
+    let identity_key_pair = identity_key_store.get_identity_key_pair(ctx).await?;
     let ctext = sealed_sender_multi_recipient_encrypt(
+        &identity_key_pair,
         recipients,
+        recipient_identities,
         recipient_sessions,
         content,
-        identity_key_store,
-        ctx,
         &mut rng,
     )
     .await?;
@@ -1091,18 +1093,20 @@ async fn SealedSender_MultiRecipientEncrypt<E: Env>(
 async fn SealedSender_MultiRecipientEncryptNode<E: Env>(
     env: E,
     recipients: &[&ProtocolAddress],
+    recipient_identities: &[&PublicKey],
     recipient_sessions: &[SessionRecord],
     content: &UnidentifiedSenderMessageContent,
     identity_key_store: &mut dyn IdentityKeyStore,
     ctx: Context,
 ) -> Result<E::Buffer> {
     let mut rng = rand::rngs::OsRng;
+    let identity_key_pair = identity_key_store.get_identity_key_pair(ctx).await?;
     let ctext = sealed_sender_multi_recipient_encrypt(
+        &identity_key_pair,
         recipients,
+        &recipient_identities,
         &recipient_sessions.iter().collect::<Vec<&SessionRecord>>(),
         content,
-        identity_key_store,
-        ctx,
         &mut rng,
     )
     .await?;

--- a/rust/bridge/shared/src/protocol.rs
+++ b/rust/bridge/shared/src/protocol.rs
@@ -1104,7 +1104,7 @@ async fn SealedSender_MultiRecipientEncryptNode<E: Env>(
     let ctext = sealed_sender_multi_recipient_encrypt(
         &identity_key_pair,
         recipients,
-        &recipient_identities,
+        recipient_identities,
         &recipient_sessions.iter().collect::<Vec<&SessionRecord>>(),
         content,
         &mut rng,

--- a/rust/protocol/benches/sealed_sender.rs
+++ b/rust/protocol/benches/sealed_sender.rs
@@ -164,15 +164,24 @@ pub fn v2(c: &mut Criterion) {
     .expect("valid");
 
     let mut encrypt_it = || {
+        let alice_identity = alice_store
+            .get_identity_key_pair(None)
+            .now_or_never()
+            .expect("sync")
+            .expect("valid");
+        let recipients = [&bob_address];
         sealed_sender_multi_recipient_encrypt(
-            &[&bob_address],
+            &alice_identity,
+            &recipients,
+            &alice_store
+                .identity_store
+                .get_identities(&recipients)
+                .expect("present"),
             &alice_store
                 .session_store
                 .load_existing_sessions(&[&bob_address])
                 .expect("present"),
             &usmc,
-            &mut alice_store.identity_store,
-            None,
             &mut rng,
         )
         .now_or_never()
@@ -231,17 +240,25 @@ pub fn v2(c: &mut Criterion) {
             BenchmarkId::from_parameter(recipient_count),
             &recipient_count,
             |b, &recipient_count| {
+                let alice_identity = alice_store
+                    .get_identity_key_pair(None)
+                    .now_or_never()
+                    .expect("sync")
+                    .expect("valid");
                 let recipients: Vec<_> = recipients.iter().take(recipient_count).collect();
                 b.iter(|| {
                     sealed_sender_multi_recipient_encrypt(
+                        &alice_identity,
                         &recipients,
+                        &alice_store
+                            .identity_store
+                            .get_identities(&recipients)
+                            .expect("present"),
                         &alice_store
                             .session_store
                             .load_existing_sessions(&recipients)
                             .expect("present"),
                         &usmc,
-                        &mut alice_store.identity_store,
-                        None,
                         &mut rng,
                     )
                     .now_or_never()
@@ -259,17 +276,25 @@ pub fn v2(c: &mut Criterion) {
             BenchmarkId::from_parameter(device_count),
             &device_count,
             |b, &device_count| {
+                let alice_identity = alice_store
+                    .get_identity_key_pair(None)
+                    .now_or_never()
+                    .expect("sync")
+                    .expect("valid");
                 let recipients: Vec<_> = vec![&bob_address; device_count];
                 b.iter(|| {
                     sealed_sender_multi_recipient_encrypt(
+                        &alice_identity,
                         &recipients,
+                        &alice_store
+                            .identity_store
+                            .get_identities(&recipients)
+                            .expect("present"),
                         &alice_store
                             .session_store
                             .load_existing_sessions(&recipients)
                             .expect("present"),
                         &usmc,
-                        &mut alice_store.identity_store,
-                        None,
                         &mut rng,
                     )
                     .now_or_never()

--- a/rust/protocol/src/error.rs
+++ b/rust/protocol/src/error.rs
@@ -36,6 +36,7 @@ pub enum SignalProtocolError {
     SignatureValidationFailed,
 
     UntrustedIdentity(crate::ProtocolAddress),
+    IdentityNotFound(String),
 
     InvalidPreKeyId,
     InvalidSignedPreKeyId,
@@ -155,6 +156,9 @@ impl fmt::Display for SignalProtocolError {
             }
             SignalProtocolError::UntrustedIdentity(addr) => {
                 write!(f, "untrusted identity for address {}", addr)
+            }
+            SignalProtocolError::IdentityNotFound(who) => {
+                write!(f, "identity with '{}' not found", who)
             }
             SignalProtocolError::SignatureValidationFailed => {
                 write!(f, "invalid signature detected")

--- a/rust/protocol/src/storage/inmem.rs
+++ b/rust/protocol/src/storage/inmem.rs
@@ -4,8 +4,8 @@
 //
 
 use crate::{
-    IdentityKey, IdentityKeyPair, PreKeyRecord, ProtocolAddress, Result, SenderKeyRecord,
-    SessionRecord, SignalProtocolError, SignedPreKeyRecord,
+    IdentityKey, IdentityKeyPair, PreKeyRecord, ProtocolAddress, PublicKey, Result,
+    SenderKeyRecord, SessionRecord, SignalProtocolError, SignedPreKeyRecord,
 };
 
 use crate::state::{PreKeyId, SignedPreKeyId};
@@ -31,6 +31,23 @@ impl InMemIdentityKeyStore {
             id,
             known_keys: HashMap::new(),
         }
+    }
+
+    /// Bulk version of [`IdentityKeyStore::get_identity`].
+    ///
+    /// Useful for [crate::sealed_sender_multi_recipient_encrypt].
+    ///
+    /// [`IdentityKeyStore::get_identity`]: crate::IdentityKeyStore::get_identity
+    pub fn get_identities(&self, addresses: &[&ProtocolAddress]) -> Result<Vec<&PublicKey>> {
+        addresses
+            .iter()
+            .map(|address| {
+                self.known_keys
+                    .get(address)
+                    .map(|key| key.public_key())
+                    .ok_or_else(|| SignalProtocolError::IdentityNotFound(address.to_string()))
+            })
+            .collect()
     }
 }
 

--- a/rust/protocol/tests/groups.rs
+++ b/rust/protocol/tests/groups.rs
@@ -336,15 +336,19 @@ fn group_sealed_sender() -> Result<(), SignalProtocolError> {
             Some([42].to_vec()),
         )?;
 
+        let alice_identity = alice_store
+            .identity_store
+            .get_identity_key_pair(None)
+            .await?;
         let recipients = [&bob_uuid_address, &carol_uuid_address];
         let alice_ctext = sealed_sender_multi_recipient_encrypt(
+            &alice_identity,
             &recipients,
+            &alice_store.identity_store.get_identities(&recipients)?,
             &alice_store
                 .session_store
                 .load_existing_sessions(&recipients)?,
             &alice_usmc,
-            &mut alice_store.identity_store,
-            None,
             &mut csprng,
         )
         .await?;

--- a/rust/protocol/tests/sealed_sender.rs
+++ b/rust/protocol/tests/sealed_sender.rs
@@ -497,15 +497,19 @@ fn test_sealed_sender_multi_recipient() -> Result<(), SignalProtocolError> {
             None,
         )?;
 
+        let alice_identity = alice_store
+            .identity_store
+            .get_identity_key_pair(None)
+            .await?;
         let recipients = [&bob_uuid_address];
         let alice_ctext = sealed_sender_multi_recipient_encrypt(
+            &alice_identity,
             &recipients,
+            &alice_store.identity_store.get_identities(&recipients)?,
             &alice_store
                 .session_store
                 .load_existing_sessions(&recipients)?,
             &alice_usmc,
-            &mut alice_store.identity_store,
-            None,
             &mut rng,
         )
         .await?;
@@ -551,15 +555,19 @@ fn test_sealed_sender_multi_recipient() -> Result<(), SignalProtocolError> {
             None,
         )?;
 
+        let alice_identity = alice_store
+            .identity_store
+            .get_identity_key_pair(None)
+            .await?;
         let recipients = [&bob_uuid_address];
         let alice_ctext = sealed_sender_multi_recipient_encrypt(
+            &alice_identity,
             &recipients,
+            &alice_store.identity_store.get_identities(&recipients)?,
             &alice_store
                 .session_store
                 .load_existing_sessions(&recipients)?,
             &alice_usmc,
-            &mut alice_store.identity_store,
-            None,
             &mut rng,
         )
         .await?;
@@ -611,15 +619,19 @@ fn test_sealed_sender_multi_recipient() -> Result<(), SignalProtocolError> {
             None,
         )?;
 
+        let alice_identity = alice_store
+            .identity_store
+            .get_identity_key_pair(None)
+            .await?;
         let recipients = [&bob_uuid_address];
         let alice_ctext = sealed_sender_multi_recipient_encrypt(
+            &alice_identity,
             &recipients,
+            &alice_store.identity_store.get_identities(&recipients)?,
             &alice_store
                 .session_store
                 .load_existing_sessions(&recipients)?,
             &alice_usmc,
-            &mut alice_store.identity_store,
-            None,
             &mut rng,
         )
         .await?;
@@ -736,13 +748,15 @@ fn test_sealed_sender_multi_recipient_encrypt_with_archived_session(
             .load_session(&bob_uuid_address, None)
             .await?
             .expect("present");
+        let alice_identity = alice_store.get_identity_key_pair(None).await?;
+        let bob_pubkey = *bob_store.get_identity_key_pair(None).await?.public_key();
         session.archive_current_state()?;
         match sealed_sender_multi_recipient_encrypt(
+            &alice_identity,
             &recipients,
+            &[&bob_pubkey],
             &[&session],
             &alice_usmc,
-            &mut alice_store.identity_store,
-            None,
             &mut rng,
         )
         .await

--- a/swift/Sources/SignalClient/DataStoreInMemory.swift
+++ b/swift/Sources/SignalClient/DataStoreInMemory.swift
@@ -62,6 +62,15 @@ public class InMemorySignalProtocolStore: IdentityKeyStore, PreKeyStore, SignedP
         return publicKeys[address]
     }
 
+    public func identities(for addresses: [ProtocolAddress], context: StoreContext) throws -> [IdentityKey] {
+        return try addresses.map { address in
+            if let publicKey = publicKeys[address] {
+                return publicKey
+            }
+            throw SignalError.identityNotFound("\(address)")
+        }
+    }
+
     public func loadPreKey(id: UInt32, context: StoreContext) throws -> PreKeyRecord {
         if let record = prekeyMap[id] {
             return record

--- a/swift/Sources/SignalClient/DataStoreProtocols.swift
+++ b/swift/Sources/SignalClient/DataStoreProtocols.swift
@@ -22,6 +22,7 @@ public protocol IdentityKeyStore: AnyObject {
     func saveIdentity(_ identity: IdentityKey, for address: ProtocolAddress, context: StoreContext) throws -> Bool
     func isTrustedIdentity(_ identity: IdentityKey, for address: ProtocolAddress, direction: Direction, context: StoreContext) throws -> Bool
     func identity(for address: ProtocolAddress, context: StoreContext) throws -> IdentityKey?
+    func identities(for addresses: [ProtocolAddress], context: StoreContext) throws -> [IdentityKey]
 }
 
 public protocol PreKeyStore: AnyObject {

--- a/swift/Sources/SignalClient/Error.swift
+++ b/swift/Sources/SignalClient/Error.swift
@@ -22,6 +22,7 @@ public enum SignalError: Error {
     case legacyCiphertextVersion(String)
     case unknownCiphertextVersion(String)
     case unrecognizedMessageVersion(String)
+    case identityNotFound(String)
     case invalidMessage(String)
     case invalidKey(String)
     case invalidSignature(String)
@@ -80,6 +81,8 @@ internal func checkError(_ error: SignalFfiErrorRef?) throws {
         throw SignalError.fingerprintParsingError(errStr)
     case SignalErrorCode_SealedSenderSelfSend:
         throw SignalError.sealedSenderSelfSend(errStr)
+    case SignalErrorCode_IdentityNotFound:
+        throw SignalError.identityNotFound(errStr)
     case SignalErrorCode_InvalidKey:
         throw SignalError.invalidKey(errStr)
     case SignalErrorCode_InvalidSignature:

--- a/swift/Sources/SignalClient/SealedSender.swift
+++ b/swift/Sources/SignalClient/SealedSender.swift
@@ -153,17 +153,19 @@ public func sealedSenderMultiRecipientEncrypt(_ content: UnidentifiedSenderMessa
                                               sessionStore: SessionStore,
                                               context: StoreContext) throws -> [UInt8] {
     let sessions = try sessionStore.loadExistingSessions(for: recipients, context: context)
+    let identities = try identityStore.identities(for: recipients, context: context)
     return try context.withOpaquePointer { context in
-        try withIdentityKeyStore(identityStore) { ffiIdentityStore in
-            try invokeFnReturningArray {
-                signal_sealed_sender_multi_recipient_encrypt($0, $1,
-                                                             recipients.map { $0.nativeHandle },
-                                                             recipients.count,
-                                                             sessions.map { $0.nativeHandle },
-                                                             sessions.count,
-                                                             content.nativeHandle,
-                                                             ffiIdentityStore, context)
-            }
+        let our_identity = identityStore.identityKeyPair(context);
+        try invokeFnReturningArray {
+            signal_sealed_sender_multi_recipient_encrypt($0, $1,
+                                                         our_identity.nativeHandle,
+                                                         recipients.map { $0.nativeHandle },
+                                                         recipients.count,
+                                                         identities.map { $0.nativeHandle },
+                                                         identities.count,
+                                                         sessions.map { $0.nativeHandle },
+                                                         sessions.count,
+                                                         content.nativeHandle)
         }
     }
 }

--- a/swift/Sources/SignalFfi/signal_ffi.h
+++ b/swift/Sources/SignalFfi/signal_ffi.h
@@ -961,7 +961,7 @@ SignalFfiError *signal_sealed_sender_multi_recipient_encrypt(const unsigned char
                                                              const SignalProtocolAddress *const *recipients,
                                                              size_t recipients_len,
                                                              const SignalPublicKey *const *recipient_identities,
-                                                             size_t recipients_identities_len,
+                                                             size_t recipient_identities_len,
                                                              const SignalSessionRecord *const *recipient_sessions,
                                                              size_t recipient_sessions_len,
                                                              const SignalUnidentifiedSenderMessageContent *content);

--- a/swift/Sources/SignalFfi/signal_ffi.h
+++ b/swift/Sources/SignalFfi/signal_ffi.h
@@ -62,6 +62,7 @@ typedef enum {
   SignalErrorCode_FingerprintVersionMismatch = 51,
   SignalErrorCode_FingerprintParsingError = 52,
   SignalErrorCode_UntrustedIdentity = 60,
+  SignalErrorCode_IdentityNotFound = 61,
   SignalErrorCode_InvalidKeyIdentifier = 70,
   SignalErrorCode_SessionNotFound = 80,
   SignalErrorCode_DuplicatedMessage = 90,
@@ -956,13 +957,14 @@ SignalFfiError *signal_sealed_session_cipher_encrypt(const unsigned char **out,
 
 SignalFfiError *signal_sealed_sender_multi_recipient_encrypt(const unsigned char **out,
                                                              size_t *out_len,
+                                                             SignalPrivateKey *our_identity,
                                                              const SignalProtocolAddress *const *recipients,
                                                              size_t recipients_len,
+                                                             const SignalPublicKey *const *recipient_identities,
+                                                             size_t recipients_identities_len,
                                                              const SignalSessionRecord *const *recipient_sessions,
                                                              size_t recipient_sessions_len,
-                                                             const SignalUnidentifiedSenderMessageContent *content,
-                                                             const SignalIdentityKeyStore *identity_key_store,
-                                                             void *ctx);
+                                                             const SignalUnidentifiedSenderMessageContent *content);
 
 SignalFfiError *signal_sealed_sender_multi_recipient_message_for_single_recipient(const unsigned char **out,
                                                                                   size_t *out_len,


### PR DESCRIPTION
Instead of fetching identity keys for each recipient one-by-one with
this change we will fetch them in bulk before calling low-level
`sealed_sender_multi_recipient_encrypt`.

This is most beneficial for the Node.js library since every asynchronous
fetch there would interrupt event-loop and make encryption slower.

cc @jrose-signal 