### PR TITLE
Java: Ensure finalizers don't run until Native calls complete

### DIFF
--- a/java/java/src/main/java/org/signal/client/internal/Native.java
+++ b/java/java/src/main/java/org/signal/client/internal/Native.java
@@ -70,6 +70,21 @@ public final class Native {
 
   private Native() {}
 
+  /**
+   * Keeps an object from being garbage-collected until this call completes.
+   *
+   * This can be used to keep a Java wrapper around a Rust object handle alive while
+   * earlier calls use that Rust object handle. That is, you should call {@code keepAlive} 
+   * <em>after</em> the code where an object must not be garbage-collected.
+   * However, most of the time {@link NativeHandleGuard} is a better choice,
+   * since the lifetime of the guard is clear.
+   *
+   * Effectively equivalent to Java 9's <a href="https://docs.oracle.com/javase/9/docs/api/java/lang/ref/Reference.html#reachabilityFence-java.lang.Object-"><code>reachabilityFence()</code></a>.
+   * Uses {@code native} because the JVM can't look into the implementation of the method
+   * and optimize away the use of {@code obj}. (The actual implementation does nothing.)
+   */
+  public static native void keepAlive(Object obj);
+
   public static native void Aes256Ctr32_Destroy(long handle);
   public static native long Aes256Ctr32_New(byte[] key, byte[] nonce, int initialCtr);
   public static native void Aes256Ctr32_Process(long ctr, byte[] data, int offset, int length);

--- a/java/java/src/main/java/org/signal/client/internal/NativeHandleGuard.java
+++ b/java/java/src/main/java/org/signal/client/internal/NativeHandleGuard.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (C) 2021 Open Whisper Systems
+ *
+ * Licensed according to the LICENSE file in this repository.
+ */
+
+package org.signal.client.internal;
+
+/**
+ * Provides access to a Rust object handle while keeping the Java wrapper alive.
+ *
+ * Intended for use with try-with-resources syntax. NativeHandleGuard prevents the Java wrapper from
+ * being finalized, which would destroy the Rust object, while the handle is in use.
+ * To use it, the Java wrapper type should conform to the {@link NativeHandleGuard.Owner} interface.
+ * 
+ * Note that it is not necessary to use NativeHandleGuard in the implementation of {@code finalize} 
+ * itself. The point of NativeHandleGuard is to delay finalization while the Rust object is being
+ * used; once finalization has begun, there can be no other uses of the Rust object from Java.
+ */
+public class NativeHandleGuard implements AutoCloseable {
+    /**
+     * @see NativeHandleGuard
+     */
+    public static interface Owner {
+        long unsafeNativeHandleWithoutGuard();
+    }
+
+    private final Owner owner;
+
+    public NativeHandleGuard(Owner owner) {
+        this.owner = owner;
+    }
+
+    /**
+     * Returns the native handle owned by the Java object, or 0 if the owner is {@code null}.
+     */
+    public long nativeHandle() {
+        if (owner == null) {
+            return 0;
+        }
+        return owner.unsafeNativeHandleWithoutGuard();
+    }
+
+    public void close() {
+        // Act as an optimization barrier, so the whole guard doesn't get inlined away.
+        // (In Java 9 we'd use Reference.reachabilityFence() for the same effect.)
+        Native.keepAlive(this.owner);
+    }
+}

--- a/java/java/src/main/java/org/signal/libsignal/crypto/Aes256Ctr32.java
+++ b/java/java/src/main/java/org/signal/libsignal/crypto/Aes256Ctr32.java
@@ -6,26 +6,34 @@
 package org.signal.libsignal.crypto;
 
 import org.signal.client.internal.Native;
+import org.signal.client.internal.NativeHandleGuard;
 import org.whispersystems.libsignal.InvalidKeyException;
 
-public class Aes256Ctr32 {
-  private final long handle;
+public class Aes256Ctr32 implements NativeHandleGuard.Owner {
+  private final long unsafeHandle;
 
   public Aes256Ctr32(byte[] key, byte[] nonce, int initialCtr) throws InvalidKeyException {
-    this.handle = Native.Aes256Ctr32_New(key, nonce, initialCtr);
+    this.unsafeHandle = Native.Aes256Ctr32_New(key, nonce, initialCtr);
   }
 
   @Override
   protected void finalize() {
-    Native.Aes256Ctr32_Destroy(this.handle);
+    Native.Aes256Ctr32_Destroy(this.unsafeHandle);
+  }
+
+  public long unsafeNativeHandleWithoutGuard() {
+    return this.unsafeHandle;
   }
 
   public void process(byte[] data) {
-    Native.Aes256Ctr32_Process(this.handle, data, 0, data.length);
+    try (NativeHandleGuard guard = new NativeHandleGuard(this)) {
+      Native.Aes256Ctr32_Process(guard.nativeHandle(), data, 0, data.length);
+    }
   }
 
   public void process(byte[] data, int offset, int length) {
-    Native.Aes256Ctr32_Process(this.handle, data, offset, length);
+    try (NativeHandleGuard guard = new NativeHandleGuard(this)) {
+      Native.Aes256Ctr32_Process(guard.nativeHandle(), data, offset, length);
+    }
   }
-
 }

--- a/java/java/src/main/java/org/signal/libsignal/crypto/Aes256GcmEncryption.java
+++ b/java/java/src/main/java/org/signal/libsignal/crypto/Aes256GcmEncryption.java
@@ -6,33 +6,44 @@
 package org.signal.libsignal.crypto;
 
 import org.signal.client.internal.Native;
+import org.signal.client.internal.NativeHandleGuard;
 import org.whispersystems.libsignal.InvalidKeyException;
 
-public class Aes256GcmEncryption {
-  private long handle;
+public class Aes256GcmEncryption implements NativeHandleGuard.Owner {
+  private long unsafeHandle;
 
   public Aes256GcmEncryption(byte[] key, byte[] nonce, byte[] associatedData) throws InvalidKeyException {
-    this.handle = Native.Aes256GcmEncryption_New(key, nonce, associatedData);
+    this.unsafeHandle = Native.Aes256GcmEncryption_New(key, nonce, associatedData);
   }
 
   @Override
   protected void finalize() {
-    Native.Aes256GcmEncryption_Destroy(this.handle);
+    Native.Aes256GcmEncryption_Destroy(this.unsafeHandle);
+  }
+
+  public long unsafeNativeHandleWithoutGuard() {
+    return this.unsafeHandle;
   }
 
   public void encrypt(byte[] plaintext, int offset, int length) {
-     Native.Aes256GcmEncryption_Update(this.handle, plaintext, offset, length);
+    try (NativeHandleGuard guard = new NativeHandleGuard(this)) {
+      Native.Aes256GcmEncryption_Update(guard.nativeHandle(), plaintext, offset, length);
+    }
   }
 
   public void encrypt(byte[] plaintext) {
-    Native.Aes256GcmEncryption_Update(this.handle, plaintext, 0, plaintext.length);
+    try (NativeHandleGuard guard = new NativeHandleGuard(this)) {
+      Native.Aes256GcmEncryption_Update(guard.nativeHandle(), plaintext, 0, plaintext.length);
+    }
   }
 
   public byte[] computeTag() {
-    byte[] tag = Native.Aes256GcmEncryption_ComputeTag(this.handle);
-    Native.Aes256GcmEncryption_Destroy(this.handle);
-    this.handle = 0;
-    return tag;
+    try (NativeHandleGuard guard = new NativeHandleGuard(this)) {
+      byte[] tag = Native.Aes256GcmEncryption_ComputeTag(guard.nativeHandle());
+      Native.Aes256GcmEncryption_Destroy(guard.nativeHandle());
+      this.unsafeHandle = 0;
+      return tag;
+    }
   }
 
 }

--- a/java/java/src/main/java/org/signal/libsignal/metadata/certificate/CertificateValidator.java
+++ b/java/java/src/main/java/org/signal/libsignal/metadata/certificate/CertificateValidator.java
@@ -1,6 +1,7 @@
 package org.signal.libsignal.metadata.certificate;
 
 import org.signal.client.internal.Native;
+import org.signal.client.internal.NativeHandleGuard;
 
 import org.whispersystems.libsignal.ecc.Curve;
 import org.whispersystems.libsignal.ecc.ECPublicKey;
@@ -18,8 +19,11 @@ public class CertificateValidator {
   }
 
   public void validate(SenderCertificate certificate, long validationTime) throws InvalidCertificateException {
-    try {
-       if (!Native.SenderCertificate_Validate(certificate.nativeHandle(), trustRoot.nativeHandle(), validationTime)) {
+    try (
+      NativeHandleGuard certificateGuard = new NativeHandleGuard(certificate);
+      NativeHandleGuard trustRootGuard = new NativeHandleGuard(trustRoot);
+    ) {
+       if (!Native.SenderCertificate_Validate(certificateGuard.nativeHandle(), trustRootGuard.nativeHandle(), validationTime)) {
          throw new InvalidCertificateException("Validation failed");
        }
     } catch (Exception e) {

--- a/java/java/src/main/java/org/signal/libsignal/metadata/certificate/SenderCertificate.java
+++ b/java/java/src/main/java/org/signal/libsignal/metadata/certificate/SenderCertificate.java
@@ -1,54 +1,65 @@
 package org.signal.libsignal.metadata.certificate;
 
 import org.signal.client.internal.Native;
+import org.signal.client.internal.NativeHandleGuard;
 
 import org.whispersystems.libsignal.ecc.ECPublicKey;
 import org.whispersystems.libsignal.InvalidKeyException;
 import org.whispersystems.libsignal.InvalidMessageException;
 import org.whispersystems.libsignal.util.guava.Optional;
 
-public class SenderCertificate {
-  private long handle;
+public class SenderCertificate implements NativeHandleGuard.Owner {
+  private final long unsafeHandle;
 
   @Override
   protected void finalize() {
-     Native.SenderCertificate_Destroy(this.handle);
+     Native.SenderCertificate_Destroy(this.unsafeHandle);
   }
 
-  public long nativeHandle() {
-    return this.handle;
+  public long unsafeNativeHandleWithoutGuard() {
+    return this.unsafeHandle;
   }
 
   public SenderCertificate(byte[] serialized) throws InvalidCertificateException {
     try {
-      handle = Native.SenderCertificate_Deserialize(serialized);
+      unsafeHandle = Native.SenderCertificate_Deserialize(serialized);
     } catch (Exception e) {
       throw new InvalidCertificateException(e);
     }
   }
 
-  public SenderCertificate(long handle) {
-    this.handle = handle;
+  public SenderCertificate(long unsafeHandle) {
+    this.unsafeHandle = unsafeHandle;
   }
 
   public ServerCertificate getSigner() {
-    return new ServerCertificate(Native.SenderCertificate_GetServerCertificate(this.handle));
+    try (NativeHandleGuard guard = new NativeHandleGuard(this)) {
+      return new ServerCertificate(Native.SenderCertificate_GetServerCertificate(guard.nativeHandle()));
+    }
   }
 
   public ECPublicKey getKey() {
-    return new ECPublicKey(Native.SenderCertificate_GetKey(this.handle));
+    try (NativeHandleGuard guard = new NativeHandleGuard(this)) {
+      return new ECPublicKey(Native.SenderCertificate_GetKey(guard.nativeHandle()));
+    }
   }
 
   public int getSenderDeviceId() {
-    return Native.SenderCertificate_GetDeviceId(this.handle);
+    try (NativeHandleGuard guard = new NativeHandleGuard(this)) {
+      return Native.SenderCertificate_GetDeviceId(guard.nativeHandle());
+    }
   }
 
   public String getSenderUuid() {
-    return Native.SenderCertificate_GetSenderUuid(this.handle);
+    try (NativeHandleGuard guard = new NativeHandleGuard(this)) {
+      return Native.SenderCertificate_GetSenderUuid(guard.nativeHandle());
+    }
   }
 
   public Optional<String> getSenderE164() {
-    return Optional.fromNullable(Native.SenderCertificate_GetSenderE164(this.handle));
+    try (NativeHandleGuard guard = new NativeHandleGuard(this)) {
+      return Optional.fromNullable(Native.SenderCertificate_GetSenderE164(guard.nativeHandle()));
+    }
   }
 
   public String getSender() {
@@ -56,18 +67,26 @@ public class SenderCertificate {
   }
 
   public long getExpiration() {
-    return Native.SenderCertificate_GetExpiration(this.handle);
+    try (NativeHandleGuard guard = new NativeHandleGuard(this)) {
+      return Native.SenderCertificate_GetExpiration(guard.nativeHandle());
+    }
   }
 
   public byte[] getSerialized() {
-    return Native.SenderCertificate_GetSerialized(this.handle);
+    try (NativeHandleGuard guard = new NativeHandleGuard(this)) {
+      return Native.SenderCertificate_GetSerialized(guard.nativeHandle());
+    }
   }
 
   public byte[] getCertificate() {
-    return Native.SenderCertificate_GetCertificate(this.handle);
+    try (NativeHandleGuard guard = new NativeHandleGuard(this)) {
+      return Native.SenderCertificate_GetCertificate(guard.nativeHandle());
+    }
   }
 
   public byte[] getSignature() {
-    return Native.SenderCertificate_GetSignature(this.handle);
+    try (NativeHandleGuard guard = new NativeHandleGuard(this)) {
+      return Native.SenderCertificate_GetSignature(guard.nativeHandle());
+    }
   }
 }

--- a/java/java/src/main/java/org/signal/libsignal/metadata/certificate/ServerCertificate.java
+++ b/java/java/src/main/java/org/signal/libsignal/metadata/certificate/ServerCertificate.java
@@ -1,53 +1,64 @@
 package org.signal.libsignal.metadata.certificate;
 
 import org.signal.client.internal.Native;
+import org.signal.client.internal.NativeHandleGuard;
 
 import org.whispersystems.libsignal.ecc.ECPublicKey;
 import org.whispersystems.libsignal.InvalidKeyException;
 import org.whispersystems.libsignal.InvalidMessageException;
 import org.whispersystems.libsignal.ecc.ECPublicKey;
 
-public class ServerCertificate {
-  private final long handle;
+public class ServerCertificate implements NativeHandleGuard.Owner {
+  private final long unsafeHandle;
 
   @Override
   protected void finalize() {
-     Native.ServerCertificate_Destroy(this.handle);
+     Native.ServerCertificate_Destroy(this.unsafeHandle);
   }
 
-  public ServerCertificate(long handle) {
-    this.handle = handle;
+  public ServerCertificate(long unsafeHandle) {
+    this.unsafeHandle = unsafeHandle;
   }
 
   public ServerCertificate(byte[] serialized) throws InvalidCertificateException {
     try {
-      this.handle = Native.ServerCertificate_Deserialize(serialized);
+      this.unsafeHandle = Native.ServerCertificate_Deserialize(serialized);
     } catch (Exception e) {
       throw new InvalidCertificateException(e);
     }
   }
 
   public int getKeyId() {
-    return Native.ServerCertificate_GetKeyId(this.handle);
+    try (NativeHandleGuard guard = new NativeHandleGuard(this)) {
+      return Native.ServerCertificate_GetKeyId(guard.nativeHandle());
+    }
   }
 
   public ECPublicKey getKey() {
-    return new ECPublicKey(Native.ServerCertificate_GetKey(this.handle));
+    try (NativeHandleGuard guard = new NativeHandleGuard(this)) {
+      return new ECPublicKey(Native.ServerCertificate_GetKey(guard.nativeHandle()));
+    }
   }
 
   public byte[] getSerialized() {
-    return Native.ServerCertificate_GetSerialized(this.handle);
+    try (NativeHandleGuard guard = new NativeHandleGuard(this)) {
+      return Native.ServerCertificate_GetSerialized(guard.nativeHandle());
+    }
   }
 
   public byte[] getCertificate() {
-    return Native.ServerCertificate_GetCertificate(this.handle);
+    try (NativeHandleGuard guard = new NativeHandleGuard(this)) {
+      return Native.ServerCertificate_GetCertificate(guard.nativeHandle());
+    }
   }
 
   public byte[] getSignature() {
-    return Native.ServerCertificate_GetSignature(this.handle);
+    try (NativeHandleGuard guard = new NativeHandleGuard(this)) {
+      return Native.ServerCertificate_GetSignature(guard.nativeHandle());
+    }
   }
 
-  public long nativeHandle() {
-    return this.handle;
+  public long unsafeNativeHandleWithoutGuard() {
+    return this.unsafeHandle;
   }
 }

--- a/java/java/src/main/java/org/whispersystems/libsignal/IdentityKey.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/IdentityKey.java
@@ -60,8 +60,4 @@ public class IdentityKey {
   public int hashCode() {
     return publicKey.hashCode();
   }
-
-  public long nativeHandle() {
-    return publicKey.nativeHandle();
-  }
 }

--- a/java/java/src/main/java/org/whispersystems/libsignal/IdentityKeyPair.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/IdentityKeyPair.java
@@ -6,6 +6,7 @@
 package org.whispersystems.libsignal;
 
 import org.signal.client.internal.Native;
+import org.signal.client.internal.NativeHandleGuard;
 
 import org.whispersystems.libsignal.ecc.ECPrivateKey;
 
@@ -41,6 +42,11 @@ public class IdentityKeyPair {
   }
 
   public byte[] serialize() {
-    return Native.IdentityKeyPair_Serialize(this.publicKey.nativeHandle(), this.privateKey.nativeHandle());
+    try (
+      NativeHandleGuard publicKey = new NativeHandleGuard(this.publicKey.getPublicKey());
+      NativeHandleGuard privateKey = new NativeHandleGuard(this.privateKey);
+    ) {
+      return Native.IdentityKeyPair_Serialize(publicKey.nativeHandle(), privateKey.nativeHandle());
+    }
   }
 }

--- a/java/java/src/main/java/org/whispersystems/libsignal/SessionBuilder.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/SessionBuilder.java
@@ -6,6 +6,7 @@
 package org.whispersystems.libsignal;
 
 import org.signal.client.internal.Native;
+import org.signal.client.internal.NativeHandleGuard;
 
 import org.whispersystems.libsignal.logging.Log;
 import org.whispersystems.libsignal.state.IdentityKeyStore;
@@ -85,10 +86,15 @@ public class SessionBuilder {
    *                                                                  trusted.
    */
   public void process(PreKeyBundle preKey) throws InvalidKeyException, UntrustedIdentityException {
-    Native.SessionBuilder_ProcessPreKeyBundle(preKey.nativeHandle(),
-                                              remoteAddress.nativeHandle(),
-                                              sessionStore,
-                                              identityKeyStore,
-                                              null);
+    try (
+      NativeHandleGuard preKeyGuard = new NativeHandleGuard(preKey);
+      NativeHandleGuard remoteAddressGuard = new NativeHandleGuard(this.remoteAddress);
+    ) {
+      Native.SessionBuilder_ProcessPreKeyBundle(preKeyGuard.nativeHandle(),
+                                                remoteAddressGuard.nativeHandle(),
+                                                sessionStore,
+                                                identityKeyStore,
+                                                null);
+    }
   }
 }

--- a/java/java/src/main/java/org/whispersystems/libsignal/SignalProtocolAddress.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/SignalProtocolAddress.java
@@ -6,29 +6,34 @@
 package org.whispersystems.libsignal;
 
 import org.signal.client.internal.Native;
+import org.signal.client.internal.NativeHandleGuard;
 
-public class SignalProtocolAddress {
-  private final long handle;
+public class SignalProtocolAddress implements NativeHandleGuard.Owner {
+  private final long unsafeHandle;
 
   public SignalProtocolAddress(String name, int deviceId) {
-    this.handle = Native.ProtocolAddress_New(name, deviceId);
+    this.unsafeHandle = Native.ProtocolAddress_New(name, deviceId);
   }
 
-  public SignalProtocolAddress(long handle) {
-    this.handle = handle;
+  public SignalProtocolAddress(long unsafeHandle) {
+    this.unsafeHandle = unsafeHandle;
   }
 
   @Override
   protected void finalize() {
-    Native.ProtocolAddress_Destroy(this.handle);
+    Native.ProtocolAddress_Destroy(this.unsafeHandle);
   }
 
   public String getName() {
-    return Native.ProtocolAddress_Name(this.handle);
+    try (NativeHandleGuard guard = new NativeHandleGuard(this)) {
+      return Native.ProtocolAddress_Name(guard.nativeHandle());
+    }
   }
 
   public int getDeviceId() {
-    return Native.ProtocolAddress_DeviceId(this.handle);
+    try (NativeHandleGuard guard = new NativeHandleGuard(this)) {
+      return Native.ProtocolAddress_DeviceId(guard.nativeHandle());
+    }
   }
 
   @Override
@@ -50,7 +55,7 @@ public class SignalProtocolAddress {
     return this.getName().hashCode() ^ this.getDeviceId();
   }
 
-  public long nativeHandle() {
-    return this.handle;
+  public long unsafeNativeHandleWithoutGuard() {
+    return this.unsafeHandle;
   }
 }

--- a/java/java/src/main/java/org/whispersystems/libsignal/groups/GroupCipher.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/groups/GroupCipher.java
@@ -6,6 +6,7 @@
 package org.whispersystems.libsignal.groups;
 
 import org.signal.client.internal.Native;
+import org.signal.client.internal.NativeHandleGuard;
 import org.whispersystems.libsignal.DuplicateMessageException;
 import org.whispersystems.libsignal.InvalidKeyIdException;
 import org.whispersystems.libsignal.InvalidMessageException;
@@ -49,8 +50,8 @@ public class GroupCipher {
    * @throws NoSessionException
    */
   public CiphertextMessage encrypt(UUID distributionId, byte[] paddedPlaintext) throws NoSessionException {
-    try {
-      return Native.GroupCipher_EncryptMessage(this.sender.nativeHandle(), distributionId, paddedPlaintext, this.senderKeyStore, null);
+    try (NativeHandleGuard sender = new NativeHandleGuard(this.sender)) {
+      return Native.GroupCipher_EncryptMessage(sender.nativeHandle(), distributionId, paddedPlaintext, this.senderKeyStore, null);
     } catch (IllegalStateException e) {
       throw new NoSessionException(e);
     }
@@ -68,8 +69,8 @@ public class GroupCipher {
   public byte[] decrypt(byte[] senderKeyMessageBytes)
       throws LegacyMessageException, DuplicateMessageException, InvalidMessageException, NoSessionException
   {
-    try {
-      return Native.GroupCipher_DecryptMessage(this.sender.nativeHandle(), senderKeyMessageBytes, this.senderKeyStore, null);
+    try (NativeHandleGuard sender = new NativeHandleGuard(this.sender)) {
+      return Native.GroupCipher_DecryptMessage(sender.nativeHandle(), senderKeyMessageBytes, this.senderKeyStore, null);
     } catch (IllegalStateException e) {
       throw new NoSessionException(e);
     }

--- a/java/java/src/main/java/org/whispersystems/libsignal/protocol/CiphertextMessage.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/protocol/CiphertextMessage.java
@@ -19,5 +19,5 @@ public interface CiphertextMessage {
 
   public byte[] serialize();
   public int getType();
-  public long nativeHandle();
+  public long unsafeNativeHandleWithoutGuard();
 }

--- a/java/java/src/main/java/org/whispersystems/libsignal/protocol/SenderKeyDistributionMessage.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/protocol/SenderKeyDistributionMessage.java
@@ -6,6 +6,7 @@
 package org.whispersystems.libsignal.protocol;
 
 import org.signal.client.internal.Native;
+import org.signal.client.internal.NativeHandleGuard;
 
 import org.whispersystems.libsignal.InvalidKeyException;
 import org.whispersystems.libsignal.InvalidMessageException;
@@ -14,48 +15,60 @@ import org.whispersystems.libsignal.ecc.ECPublicKey;
 
 import java.util.UUID;
 
-public class SenderKeyDistributionMessage {
+public class SenderKeyDistributionMessage implements NativeHandleGuard.Owner {
 
-  private final long handle;
+  private final long unsafeHandle;
 
   @Override
   protected void finalize() {
-     Native.SenderKeyDistributionMessage_Destroy(this.handle);
+     Native.SenderKeyDistributionMessage_Destroy(this.unsafeHandle);
   }
 
-  public SenderKeyDistributionMessage(long handle) {
-    this.handle = handle;
+  public SenderKeyDistributionMessage(long unsafeHandle) {
+    this.unsafeHandle = unsafeHandle;
   }
 
   public SenderKeyDistributionMessage(byte[] serialized) throws LegacyMessageException, InvalidMessageException {
-    handle = Native.SenderKeyDistributionMessage_Deserialize(serialized);
+    unsafeHandle = Native.SenderKeyDistributionMessage_Deserialize(serialized);
   }
 
   public byte[] serialize() {
-    return Native.SenderKeyDistributionMessage_GetSerialized(this.handle);
+    try (NativeHandleGuard guard = new NativeHandleGuard(this)) {
+      return Native.SenderKeyDistributionMessage_GetSerialized(guard.nativeHandle());
+    }
   }
 
   public UUID getDistributionId() {
-    return Native.SenderKeyMessage_GetDistributionId(this.handle);
+    try (NativeHandleGuard guard = new NativeHandleGuard(this)) {
+      return Native.SenderKeyMessage_GetDistributionId(guard.nativeHandle());
+    }
   }
 
   public int getIteration() {
-    return Native.SenderKeyDistributionMessage_GetIteration(this.handle);
+    try (NativeHandleGuard guard = new NativeHandleGuard(this)) {
+      return Native.SenderKeyDistributionMessage_GetIteration(guard.nativeHandle());
+    }
   }
 
   public byte[] getChainKey() {
-    return Native.SenderKeyDistributionMessage_GetChainKey(this.handle);
+    try (NativeHandleGuard guard = new NativeHandleGuard(this)) {
+      return Native.SenderKeyDistributionMessage_GetChainKey(guard.nativeHandle());
+    }
   }
 
   public ECPublicKey getSignatureKey() {
-    return new ECPublicKey(Native.SenderKeyDistributionMessage_GetSignatureKey(this.handle));
+    try (NativeHandleGuard guard = new NativeHandleGuard(this)) {
+      return new ECPublicKey(Native.SenderKeyDistributionMessage_GetSignatureKey(guard.nativeHandle()));
+    }
   }
 
   public int getChainId() {
-    return Native.SenderKeyDistributionMessage_GetChainId(this.handle);
+    try (NativeHandleGuard guard = new NativeHandleGuard(this)) {
+      return Native.SenderKeyDistributionMessage_GetChainId(guard.nativeHandle());
+    }
   }
 
-  public long nativeHandle() {
-    return this.handle;
+  public long unsafeNativeHandleWithoutGuard() {
+    return this.unsafeHandle;
   }
 }

--- a/java/java/src/main/java/org/whispersystems/libsignal/protocol/SignalMessage.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/protocol/SignalMessage.java
@@ -6,6 +6,7 @@
 package org.whispersystems.libsignal.protocol;
 
 import org.signal.client.internal.Native;
+import org.signal.client.internal.NativeHandleGuard;
 import org.whispersystems.libsignal.IdentityKey;
 import org.whispersystems.libsignal.InvalidKeyException;
 import org.whispersystems.libsignal.InvalidMessageException;
@@ -15,52 +16,69 @@ import org.whispersystems.libsignal.util.ByteUtil;
 
 import javax.crypto.spec.SecretKeySpec;
 
-public class SignalMessage implements CiphertextMessage {
-  private final long handle;
+public class SignalMessage implements CiphertextMessage, NativeHandleGuard.Owner {
+  private final long unsafeHandle;
 
   @Override
   protected void finalize() {
-     Native.SignalMessage_Destroy(this.handle);
+     Native.SignalMessage_Destroy(this.unsafeHandle);
   }
 
   public SignalMessage(byte[] serialized) throws InvalidMessageException, LegacyMessageException {
-    handle = Native.SignalMessage_Deserialize(serialized);
+    unsafeHandle = Native.SignalMessage_Deserialize(serialized);
   }
 
-  public SignalMessage(long handle) {
-    this.handle = handle;
+  public SignalMessage(long unsafeHandle) {
+    this.unsafeHandle = unsafeHandle;
   }
 
   public ECPublicKey getSenderRatchetKey()  {
-    return new ECPublicKey(Native.SignalMessage_GetSenderRatchetKey(this.handle));
+    try (NativeHandleGuard guard = new NativeHandleGuard(this)) {
+      return new ECPublicKey(Native.SignalMessage_GetSenderRatchetKey(guard.nativeHandle()));
+    }
   }
 
   public int getMessageVersion() {
-    return Native.SignalMessage_GetMessageVersion(this.handle);
+    try (NativeHandleGuard guard = new NativeHandleGuard(this)) {
+      return Native.SignalMessage_GetMessageVersion(guard.nativeHandle());
+    }
   }
 
   public int getCounter() {
-    return Native.SignalMessage_GetCounter(this.handle);
+    try (NativeHandleGuard guard = new NativeHandleGuard(this)) {
+      return Native.SignalMessage_GetCounter(guard.nativeHandle());
+    }
   }
 
   public byte[] getBody() {
-    return Native.SignalMessage_GetBody(this.handle);
+    try (NativeHandleGuard guard = new NativeHandleGuard(this)) {
+      return Native.SignalMessage_GetBody(guard.nativeHandle());
+    }
   }
 
   public void verifyMac(IdentityKey senderIdentityKey, IdentityKey receiverIdentityKey, SecretKeySpec macKey)
       throws InvalidMessageException
   {
-    if(!Native.SignalMessage_VerifyMac(this.handle,
-                  senderIdentityKey.getPublicKey().nativeHandle(),
-                  receiverIdentityKey.getPublicKey().nativeHandle(),
-                  macKey.getEncoded())) {
-      throw new InvalidMessageException("Bad Mac!");
+    try (
+      NativeHandleGuard guard = new NativeHandleGuard(this);
+      NativeHandleGuard senderIdentityGuard = new NativeHandleGuard(senderIdentityKey.getPublicKey());
+      NativeHandleGuard receiverIdentityGuard = new NativeHandleGuard(receiverIdentityKey.getPublicKey());
+    ) {
+      if (!Native.SignalMessage_VerifyMac(
+          guard.nativeHandle(),
+          senderIdentityGuard.nativeHandle(),
+          receiverIdentityGuard.nativeHandle(),
+          macKey.getEncoded())) {
+        throw new InvalidMessageException("Bad Mac!");
+      }
     }
   }
 
   @Override
   public byte[] serialize() {
-    return Native.SignalMessage_GetSerialized(this.handle);
+    try (NativeHandleGuard guard = new NativeHandleGuard(this)) {
+      return Native.SignalMessage_GetSerialized(guard.nativeHandle());
+    }
   }
 
   @Override
@@ -68,8 +86,8 @@ public class SignalMessage implements CiphertextMessage {
     return CiphertextMessage.WHISPER_TYPE;
   }
 
-  public long nativeHandle() {
-    return this.handle;
+  public long unsafeNativeHandleWithoutGuard() {
+    return this.unsafeHandle;
   }
 
   public static boolean isLegacy(byte[] message) {

--- a/java/java/src/main/java/org/whispersystems/libsignal/state/SignedPreKeyRecord.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/state/SignedPreKeyRecord.java
@@ -6,6 +6,7 @@
 package org.whispersystems.libsignal.state;
 
 import org.signal.client.internal.Native;
+import org.signal.client.internal.NativeHandleGuard;
 import org.whispersystems.libsignal.InvalidKeyException;
 import org.whispersystems.libsignal.ecc.ECKeyPair;
 import org.whispersystems.libsignal.ecc.ECPrivateKey;
@@ -13,49 +14,66 @@ import org.whispersystems.libsignal.ecc.ECPublicKey;
 
 import java.io.IOException;
 
-public class SignedPreKeyRecord {
-  private long handle;
+public class SignedPreKeyRecord implements NativeHandleGuard.Owner {
+  private final long unsafeHandle;
 
   @Override
   protected void finalize() {
-    Native.SignedPreKeyRecord_Destroy(this.handle);
+    Native.SignedPreKeyRecord_Destroy(this.unsafeHandle);
   }
 
   public SignedPreKeyRecord(int id, long timestamp, ECKeyPair keyPair, byte[] signature) {
-    this.handle = Native.SignedPreKeyRecord_New(id, timestamp,
-                      keyPair.getPublicKey().nativeHandle(),
-                      keyPair.getPrivateKey().nativeHandle(),
-                      signature);
+    try (
+      NativeHandleGuard publicGuard = new NativeHandleGuard(keyPair.getPublicKey());
+      NativeHandleGuard privateGuard = new NativeHandleGuard(keyPair.getPrivateKey());
+    ) {
+      this.unsafeHandle = Native.SignedPreKeyRecord_New(
+        id,
+        timestamp,
+        publicGuard.nativeHandle(),
+        privateGuard.nativeHandle(),
+        signature);
+    }
   }
 
   public SignedPreKeyRecord(byte[] serialized) throws IOException {
-    this.handle = Native.SignedPreKeyRecord_Deserialize(serialized);
+    this.unsafeHandle = Native.SignedPreKeyRecord_Deserialize(serialized);
   }
 
   public int getId() {
-    return Native.SignedPreKeyRecord_GetId(this.handle);
+    try (NativeHandleGuard guard = new NativeHandleGuard(this)) {
+      return Native.SignedPreKeyRecord_GetId(guard.nativeHandle());
+    }
   }
 
   public long getTimestamp() {
-    return Native.SignedPreKeyRecord_GetTimestamp(this.handle);
+    try (NativeHandleGuard guard = new NativeHandleGuard(this)) {
+      return Native.SignedPreKeyRecord_GetTimestamp(guard.nativeHandle());
+    }
   }
 
   public ECKeyPair getKeyPair() {
-    ECPublicKey publicKey = new ECPublicKey(Native.SignedPreKeyRecord_GetPublicKey(this.handle));
-    ECPrivateKey privateKey = new ECPrivateKey(Native.SignedPreKeyRecord_GetPrivateKey(this.handle));
-    return new ECKeyPair(publicKey, privateKey);
+    try (NativeHandleGuard guard = new NativeHandleGuard(this)) {
+      ECPublicKey publicKey = new ECPublicKey(Native.SignedPreKeyRecord_GetPublicKey(guard.nativeHandle()));
+      ECPrivateKey privateKey = new ECPrivateKey(Native.SignedPreKeyRecord_GetPrivateKey(guard.nativeHandle()));
+      return new ECKeyPair(publicKey, privateKey);
+    }
   }
 
   public byte[] getSignature() {
-    return Native.SignedPreKeyRecord_GetSignature(this.handle);
+    try (NativeHandleGuard guard = new NativeHandleGuard(this)) {
+      return Native.SignedPreKeyRecord_GetSignature(guard.nativeHandle());
+    }
   }
 
   public byte[] serialize() {
-    return Native.SignedPreKeyRecord_GetSerialized(this.handle);
+    try (NativeHandleGuard guard = new NativeHandleGuard(this)) {
+      return Native.SignedPreKeyRecord_GetSerialized(guard.nativeHandle());
+    }
   }
 
-  public long nativeHandle() {
-    return this.handle;
+  public long unsafeNativeHandleWithoutGuard() {
+    return this.unsafeHandle;
   }
 
 }

--- a/java/tests/src/test/java/org/signal/libsignal/metadata/certificate/SenderCertificateTest.java
+++ b/java/tests/src/test/java/org/signal/libsignal/metadata/certificate/SenderCertificateTest.java
@@ -9,6 +9,7 @@ import org.whispersystems.libsignal.ecc.ECPublicKey;
 import org.whispersystems.libsignal.ecc.ECPrivateKey;
 
 import org.signal.client.internal.Native;
+import org.signal.client.internal.NativeHandleGuard;
 
 import java.util.UUID;
 
@@ -58,9 +59,19 @@ public class SenderCertificateTest extends TestCase {
       throws InvalidKeyException, InvalidCertificateException {
     ECKeyPair serverKey = Curve.generateKeyPair();
 
-    ServerCertificate serverCertificate = new ServerCertificate(Native.ServerCertificate_New(1, serverKey.getPublicKey().nativeHandle(), trustRoot.getPrivateKey().nativeHandle()));
+    try (
+      NativeHandleGuard serverPublicGuard = new NativeHandleGuard(serverKey.getPublicKey());
+      NativeHandleGuard trustRootPrivateGuard = new NativeHandleGuard(trustRoot.getPrivateKey());
+    ) {
+      ServerCertificate serverCertificate = new ServerCertificate(Native.ServerCertificate_New(1, serverPublicGuard.nativeHandle(), trustRootPrivateGuard.nativeHandle()));
 
-    return new SenderCertificate(Native.SenderCertificate_New(uuid.toString(), e164, deviceId, identityKey.nativeHandle(), expires,
-                                                              serverCertificate.nativeHandle(), serverKey.getPrivateKey().nativeHandle()));
+      try (
+        NativeHandleGuard identityGuard = new NativeHandleGuard(identityKey);
+        NativeHandleGuard serverCertificateGuard = new NativeHandleGuard(serverCertificate);
+        NativeHandleGuard serverPrivateGuard = new NativeHandleGuard(serverKey.getPrivateKey());
+      ) {
+        return new SenderCertificate(Native.SenderCertificate_New(uuid.toString(), e164, deviceId, identityGuard.nativeHandle(), expires, serverCertificateGuard.nativeHandle(), serverPrivateGuard.nativeHandle()));
+      }
+    }
   }
 }

--- a/rust/bridge/jni/bin/Native.java.in
+++ b/rust/bridge/jni/bin/Native.java.in
@@ -70,5 +70,20 @@ public final class Native {
 
   private Native() {}
 
+  /**
+   * Keeps an object from being garbage-collected until this call completes.
+   *
+   * This can be used to keep a Java wrapper around a Rust object handle alive while
+   * earlier calls use that Rust object handle. That is, you should call {@code keepAlive} 
+   * <em>after</em> the code where an object must not be garbage-collected.
+   * However, most of the time {@link NativeHandleGuard} is a better choice,
+   * since the lifetime of the guard is clear.
+   *
+   * Effectively equivalent to Java 9's <a href="https://docs.oracle.com/javase/9/docs/api/java/lang/ref/Reference.html#reachabilityFence-java.lang.Object-"><code>reachabilityFence()</code></a>.
+   * Uses {@code native} because the JVM can't look into the implementation of the method
+   * and optimize away the use of {@code obj}. (The actual implementation does nothing.)
+   */
+  public static native void keepAlive(Object obj);
+
   // INSERT DECLS HERE
 }

--- a/rust/bridge/jni/bin/gen_java_decl.py
+++ b/rust/bridge/jni/bin/gen_java_decl.py
@@ -122,7 +122,7 @@ template_file = open(os.path.join(our_abs_dir, 'Native.java.in')).read()
 
 contents = template_file.replace('\n  // INSERT DECLS HERE', "\n".join(decls))
 
-native_java = os.path.join(our_abs_dir, '../../../../java/java/src/main/java/org/signal/internal/Native.java')
+native_java = os.path.join(our_abs_dir, '../../../../java/java/src/main/java/org/signal/client/internal/Native.java')
 
 if not os.access(native_java, os.F_OK):
     raise Exception("Didn't find Native.java where it was expected")

--- a/rust/bridge/jni/src/lib.rs
+++ b/rust/bridge/jni/src/lib.rs
@@ -6,7 +6,7 @@
 #![allow(clippy::missing_safety_doc)]
 #![deny(clippy::unwrap_used)]
 
-use jni::objects::JClass;
+use jni::objects::{JClass, JObject};
 use jni::sys::{jbyteArray, jlongArray};
 use jni::JNIEnv;
 use std::convert::TryFrom;
@@ -34,4 +34,15 @@ pub unsafe extern "C" fn Java_org_signal_client_internal_Native_IdentityKeyPair_
         env.set_long_array_region(result, 0, &tuple)?;
         Ok(result)
     })
+}
+
+/// An optimization barrier / guard against garbage collection.
+///
+/// cbindgen:ignore
+#[no_mangle]
+pub unsafe extern "C" fn Java_org_signal_client_internal_Native_keepAlive(
+    _env: JNIEnv,
+    _class: JClass,
+    _obj: JObject,
+) {
 }

--- a/rust/bridge/shared/src/jni/convert.rs
+++ b/rust/bridge/shared/src/jni/convert.rs
@@ -317,13 +317,9 @@ impl<'a> SimpleArgTypeInfo<'a> for CiphertextMessageRef<'a> {
             make_result: fn(&'a T) -> CiphertextMessageRef<'a>,
         ) -> SignalJniResult<Option<CiphertextMessageRef<'a>>> {
             if env.is_instance_of(foreign, class_name)? {
-                let handle = call_method_checked(
-                    env,
-                    foreign,
-                    "nativeHandle",
-                    jni_signature!(() -> long),
-                    &[],
-                )?;
+                let handle: jlong = env
+                    .get_field(foreign, "unsafeHandle", jni_signature!(long))?
+                    .try_into()?;
                 Ok(Some(make_result(unsafe { native_handle_cast(handle)? })))
             } else {
                 Ok(None)

--- a/rust/bridge/shared/src/jni/mod.rs
+++ b/rust/bridge/shared/src/jni/mod.rs
@@ -573,8 +573,9 @@ pub fn get_object_with_native_handle<T: 'static + Clone>(
             return Ok(None);
         }
 
-        let handle: jlong =
-            call_method_checked(env, obj, "nativeHandle", jni_signature!(() -> long), &[])?;
+        let handle: jlong = env
+            .get_field(obj, "unsafeHandle", jni_signature!(long))?
+            .try_into()?;
         if handle == 0 {
             return Ok(None);
         }


### PR DESCRIPTION
If garbage collection happens at exactly the wrong time, the Java wrapper around a Rust object (such as SessionRecord) can be finalized while the Rust object is being used, via its opaque `nativeHandle` (address cast as integer). Avoid this by adding a NativeHandleGuard type that keeps the wrapper alive, as well as a low-level entry point `Native.keepAlive(...)` that does nothing but serve as a sort of GC guard, similar to `Reference.reachabilityFence()` in Java 9.