### PR TITLE
zkgroup: Tidy up error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2204,6 +2204,7 @@ dependencies = [
  "bincode",
  "criterion",
  "curve25519-dalek",
+ "displaydoc",
  "hex",
  "poksho",
  "serde",

--- a/rust/zkgroup/Cargo.toml
+++ b/rust/zkgroup/Cargo.toml
@@ -20,6 +20,7 @@ sha2 = "0.9.0"
 hex = "0.4.0"
 aead = "0.4.0"
 aes-gcm-siv = "0.10.0"
+displaydoc = "0.2"
 
 [dependencies.curve25519-dalek]
 features = ["serde"]

--- a/rust/zkgroup/src/common/errors.rs
+++ b/rust/zkgroup/src/common/errors.rs
@@ -1,14 +1,18 @@
 //
-// Copyright 2020 Signal Messenger, LLC.
+// Copyright 2020-2021 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-#[derive(Debug)]
+#[derive(Debug, displaydoc::Display)]
 pub enum ZkGroupError {
-    BadArgs,                      // Bad arguments were passed to the function
-    DecryptionFailure,            // Decryption failed
-    MacVerificationFailure,       // MAC verification failed
-    ProofVerificationFailure,     // Proof verification failed
-    SignatureVerificationFailure, // Signature verification failed
-    PointDecodeFailure,           // Lizard failed to decode; CAN HAPPEN
+    /// Bad arguments were passed to the function
+    BadArgs,
+    /// Decryption failed
+    DecryptionFailure,
+    /// MAC verification failed
+    MacVerificationFailure,
+    /// Proof verification failed
+    ProofVerificationFailure,
+    /// Signature verification failed
+    SignatureVerificationFailure,
 }

--- a/rust/zkgroup/src/crypto/uid_struct.rs
+++ b/rust/zkgroup/src/crypto/uid_struct.rs
@@ -5,14 +5,11 @@
 
 #![allow(non_snake_case)]
 
-use crate::common::errors::*;
 use crate::common::sho::*;
 use crate::common::simple_types::*;
 use curve25519_dalek::ristretto::RistrettoPoint;
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
-
-use ZkGroupError::*;
 
 #[derive(Copy, Clone, PartialEq, Serialize, Deserialize)]
 pub struct UidStruct {
@@ -20,6 +17,8 @@ pub struct UidStruct {
     pub(crate) M1: RistrettoPoint,
     pub(crate) M2: RistrettoPoint,
 }
+
+pub struct PointDecodeFailure;
 
 impl UidStruct {
     pub fn new(uid_bytes: UidBytes) -> Self {
@@ -33,8 +32,7 @@ impl UidStruct {
         }
     }
 
-    // Might return PointDecodeFailure
-    pub fn from_M2(M2: RistrettoPoint) -> Result<Self, ZkGroupError> {
+    pub fn from_M2(M2: RistrettoPoint) -> Result<Self, PointDecodeFailure> {
         match M2.lizard_decode::<Sha256>() {
             None => Err(PointDecodeFailure),
             Some(bytes) => Ok(Self::new(bytes)),


### PR DESCRIPTION
- Use displaydoc to stringify the errors, using the comments that were already there. These will go into the string descriptions for errors exposed to the apps, which can be useful.

- Split PointDecodeError into its own type so that it's not exposed generally.