### PR TITLE
bridge: Add support for arrays as arguments and return values

### DIFF
--- a/rust/bridge/jni/bin/gen_java_decl.py
+++ b/rust/bridge/jni/bin/gen_java_decl.py
@@ -39,7 +39,8 @@ ignore_this_warning = re.compile(
     "("
     r"WARN: Can't find .*\. This usually means that this type was incompatible or not found\.|"
     r"WARN: Missing `\[defines\]` entry for `feature = \".*\"` in cbindgen config\.|"
-    r"WARN: Skip libsignal-bridge::_ - \(not `pub`\)\."
+    r"WARN: Skip libsignal-bridge::_ - \(not `pub`\)\.|"
+    r"WARN: Couldn't find path for Array\(Path\(GenericPath \{ .+ \}\), Name\(\"LEN\"\)\), skipping associated constants"
     ")")
 
 unknown_warning = False

--- a/rust/bridge/node/bin/gen_ts_decl.py
+++ b/rust/bridge/node/bin/gen_ts_decl.py
@@ -39,6 +39,9 @@ def translate_to_ts(typ):
     if typ in type_map:
         return type_map[typ]
 
+    if typ.startswith('[u8;') or typ.startswith('&[u8;'):
+        return 'Buffer'
+
     if typ.startswith('&mutdyn'):
         return typ[7:]
 

--- a/rust/bridge/shared/src/jni/error.rs
+++ b/rust/bridge/shared/src/jni/error.rs
@@ -24,6 +24,7 @@ pub enum SignalJniError {
     SignalCrypto(SignalCryptoError),
     Jni(jni::errors::Error),
     BadJniParameter(&'static str),
+    DeserializationFailed(&'static str),
     UnexpectedJniResultType(&'static str, &'static str),
     NullHandle,
     IntegerOverflow(String),
@@ -45,6 +46,9 @@ impl fmt::Display for SignalJniError {
             }
             SignalJniError::IntegerOverflow(m) => {
                 write!(f, "integer overflow during conversion of {}", m)
+            }
+            SignalJniError::DeserializationFailed(ty) => {
+                write!(f, "failed to deserialize {}", ty)
             }
             SignalJniError::HsmEnclave(e) => {
                 write!(f, "{}", e)

--- a/rust/bridge/shared/src/jni/mod.rs
+++ b/rust/bridge/shared/src/jni/mod.rs
@@ -220,9 +220,8 @@ fn throw_error(env: &JNIEnv, error: SignalJniError) {
         SignalJniError::Signal(SignalProtocolError::InvalidArgument(_))
         | SignalJniError::SignalCrypto(SignalCryptoError::UnknownAlgorithm(_, _))
         | SignalJniError::SignalCrypto(SignalCryptoError::InvalidInputSize)
-        | SignalJniError::SignalCrypto(SignalCryptoError::InvalidNonceSize) => {
-            "java/lang/IllegalArgumentException"
-        }
+        | SignalJniError::SignalCrypto(SignalCryptoError::InvalidNonceSize)
+        | SignalJniError::DeserializationFailed(_) => "java/lang/IllegalArgumentException",
 
         SignalJniError::IntegerOverflow(_)
         | SignalJniError::Jni(_)


### PR DESCRIPTION
Specifically, adding support for *references to fixed-sized arrays* as arguments (pointer-to-fixed-size-array in C, byte[] in Java, Buffer in Node), and fixed-sized array values as results (out-pointer-to-fixed-sized-array in C, byte[] in Java, Buffer in Node). This will be used for some zkgroup primitive values.