### PR TITLE
bridge: Support UUID return values in the FFI bridge

### DIFF
--- a/rust/bridge/shared/src/ffi/convert.rs
+++ b/rust/bridge/shared/src/ffi/convert.rs
@@ -246,6 +246,13 @@ impl SimpleArgTypeInfo for uuid::Uuid {
     }
 }
 
+impl ResultTypeInfo for uuid::Uuid {
+    type ResultType = uuid::Bytes;
+    fn convert_into(self) -> SignalFfiResult<Self::ResultType> {
+        Ok(*self.as_bytes())
+    }
+}
+
 macro_rules! store {
     ($name:ident) => {
         paste! {
@@ -530,5 +537,6 @@ macro_rules! ffi_result_type {
     (Option<String>) => (*const libc::c_char);
     (Option<&str>) => (*const libc::c_char);
     (Option<$typ:ty>) => (*mut $typ);
+    (Uuid) => ([u8; 16]);
     ( $typ:ty ) => (*mut $typ);
 }

--- a/rust/bridge/shared/src/protocol.rs
+++ b/rust/bridge/shared/src/protocol.rs
@@ -336,16 +336,9 @@ bridge_get_buffer!(
     SenderKeyMessage::serialized as Serialize -> &[u8],
     jni = "SenderKeyMessage_1GetSerialized"
 );
-bridge_get!(SenderKeyMessage::distribution_id -> Uuid, ffi = false);
+bridge_get!(SenderKeyMessage::distribution_id -> Uuid);
 bridge_get!(SenderKeyMessage::chain_id -> u32);
 bridge_get!(SenderKeyMessage::iteration -> u32);
-
-// Alternate form that copies into an existing buffer.
-#[bridge_fn_void(jni = false, node = false)]
-fn SenderKeyMessageGetDistributionId(out: &mut [u8; 16], obj: &SenderKeyMessage) -> Result<()> {
-    *out = *obj.distribution_id().as_bytes();
-    Ok(())
-}
 
 // For testing
 #[bridge_fn]
@@ -392,19 +385,9 @@ bridge_get_buffer!(
     SenderKeyDistributionMessage::serialized as Serialize -> &[u8],
     jni = "SenderKeyDistributionMessage_1GetSerialized"
 );
-bridge_get!(SenderKeyDistributionMessage::distribution_id -> Uuid, ffi = false);
+bridge_get!(SenderKeyDistributionMessage::distribution_id -> Uuid);
 bridge_get!(SenderKeyDistributionMessage::chain_id -> u32);
 bridge_get!(SenderKeyDistributionMessage::iteration -> u32);
-
-// Alternate form that copies into an existing buffer.
-#[bridge_fn_void(jni = false, node = false)]
-fn SenderKeyDistributionMessageGetDistributionId(
-    out: &mut [u8; 16],
-    obj: &SenderKeyDistributionMessage,
-) -> Result<()> {
-    *out = *obj.distribution_id()?.as_bytes();
-    Ok(())
-}
 
 // For testing
 #[bridge_fn]

--- a/swift/Sources/SignalFfi/signal_ffi.h
+++ b/swift/Sources/SignalFfi/signal_ffi.h
@@ -586,14 +586,14 @@ SignalFfiError *signal_sender_key_message_serialize(const unsigned char **out,
                                                     size_t *out_len,
                                                     const SignalSenderKeyMessage *obj);
 
+SignalFfiError *signal_sender_key_message_get_distribution_id(uint8_t (*out)[16],
+                                                              const SignalSenderKeyMessage *obj);
+
 SignalFfiError *signal_sender_key_message_get_chain_id(uint32_t *out,
                                                        const SignalSenderKeyMessage *obj);
 
 SignalFfiError *signal_sender_key_message_get_iteration(uint32_t *out,
                                                         const SignalSenderKeyMessage *obj);
-
-SignalFfiError *signal_sender_key_message_get_distribution_id(uint8_t (*out)[16],
-                                                              const SignalSenderKeyMessage *obj);
 
 SignalFfiError *signal_sender_key_message_new(SignalSenderKeyMessage **out,
                                               uint8_t message_version,
@@ -620,14 +620,14 @@ SignalFfiError *signal_sender_key_distribution_message_serialize(const unsigned 
                                                                  size_t *out_len,
                                                                  const SignalSenderKeyDistributionMessage *obj);
 
+SignalFfiError *signal_sender_key_distribution_message_get_distribution_id(uint8_t (*out)[16],
+                                                                           const SignalSenderKeyDistributionMessage *obj);
+
 SignalFfiError *signal_sender_key_distribution_message_get_chain_id(uint32_t *out,
                                                                     const SignalSenderKeyDistributionMessage *obj);
 
 SignalFfiError *signal_sender_key_distribution_message_get_iteration(uint32_t *out,
                                                                      const SignalSenderKeyDistributionMessage *obj);
-
-SignalFfiError *signal_sender_key_distribution_message_get_distribution_id(uint8_t (*out)[16],
-                                                                           const SignalSenderKeyDistributionMessage *obj);
 
 SignalFfiError *signal_sender_key_distribution_message_new(SignalSenderKeyDistributionMessage **out,
                                                            uint8_t message_version,


### PR DESCRIPTION
This was already present in the Java and Node bridges; I'm not sure why it was considered a problem in the FFI bridge.