### PR TITLE
Standardize license headers

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,4 @@
-# Copyright 2021 Signal Messenger, LLC
+# Copyright 2021 Signal Messenger, LLC.
 # SPDX-License-Identifier: AGPL-3.0-only
 
 custom: https://signal.org/donate/

--- a/README.md
+++ b/README.md
@@ -130,6 +130,6 @@ Administration Regulations, Section 740.13) for both object code and source code
 
 ## License
 
-Copyright 2020-2021 Signal Messenger, LLC
+Copyright 2020-2021 Signal Messenger, LLC.
 
 Licensed under the AGPLv3: https://www.gnu.org/licenses/agpl-3.0.html

--- a/java/tests/src/test/java/org/whispersystems/libsignal/SessionRecordTest.java
+++ b/java/tests/src/test/java/org/whispersystems/libsignal/SessionRecordTest.java
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 Signal Messenger, LLC
+// Copyright 2021 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 

--- a/rust/bridge/ffi/README.md
+++ b/rust/bridge/ffi/README.md
@@ -19,7 +19,7 @@ Administration Regulations, Section 740.13) for both object code and source code
 
 ## License
 
-Copyright 2020 Signal Messenger, LLC
+Copyright 2020 Signal Messenger, LLC.
 
 Licensed under the AGPLv3: http://www.gnu.org/licenses/agpl-3.0.html
 

--- a/swift/.swiftlint.yml
+++ b/swift/.swiftlint.yml
@@ -15,6 +15,6 @@ opt_in_rules:
 file_header:
   required_pattern: |
     //
-    // Copyright \d{4}(-\d{4})? Signal Messenger, LLC
+    // Copyright \d{4}(-\d{4})? Signal Messenger, LLC.
     // SPDX-License-Identifier: AGPL-3.0-only
     //

--- a/swift/Package.swift
+++ b/swift/Package.swift
@@ -1,7 +1,7 @@
 // swift-tools-version:5.0
 
 //
-// Copyright 2020-2021 Signal Messenger, LLC
+// Copyright 2020-2021 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 

--- a/swift/Sources/SignalClient/Address.swift
+++ b/swift/Sources/SignalClient/Address.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2020-2021 Signal Messenger, LLC
+// Copyright 2020-2021 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 

--- a/swift/Sources/SignalClient/Aes256GcmSiv.swift
+++ b/swift/Sources/SignalClient/Aes256GcmSiv.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2020-2021 Signal Messenger, LLC
+// Copyright 2020-2021 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 

--- a/swift/Sources/SignalClient/DataStoreInMemory.swift
+++ b/swift/Sources/SignalClient/DataStoreInMemory.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2020-2021 Signal Messenger, LLC
+// Copyright 2020-2021 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 

--- a/swift/Sources/SignalClient/DataStoreProtocols.swift
+++ b/swift/Sources/SignalClient/DataStoreProtocols.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2020-2021 Signal Messenger, LLC
+// Copyright 2020-2021 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 

--- a/swift/Sources/SignalClient/DeviceTransfer.swift
+++ b/swift/Sources/SignalClient/DeviceTransfer.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 Signal Messenger, LLC
+// Copyright 2021 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 

--- a/swift/Sources/SignalClient/Error.swift
+++ b/swift/Sources/SignalClient/Error.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Signal Messenger, LLC
+// Copyright 2020 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 

--- a/swift/Sources/SignalClient/Fingerprint.swift
+++ b/swift/Sources/SignalClient/Fingerprint.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2020-2021 Signal Messenger, LLC
+// Copyright 2020-2021 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 

--- a/swift/Sources/SignalClient/HsmEnclave.swift
+++ b/swift/Sources/SignalClient/HsmEnclave.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 Signal Messenger, LLC
+// Copyright 2021 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 

--- a/swift/Sources/SignalClient/IdentityKey.swift
+++ b/swift/Sources/SignalClient/IdentityKey.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2020-2021 Signal Messenger, LLC
+// Copyright 2020-2021 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 

--- a/swift/Sources/SignalClient/Kdf.swift
+++ b/swift/Sources/SignalClient/Kdf.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Signal Messenger, LLC
+// Copyright 2020 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 

--- a/swift/Sources/SignalClient/Logging.m
+++ b/swift/Sources/SignalClient/Logging.m
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Signal Messenger, LLC
+// Copyright 2020 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 

--- a/swift/Sources/SignalClient/NativeHandleOwner.swift
+++ b/swift/Sources/SignalClient/NativeHandleOwner.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2020-2021 Signal Messenger, LLC
+// Copyright 2020-2021 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 

--- a/swift/Sources/SignalClient/PrivateKey.swift
+++ b/swift/Sources/SignalClient/PrivateKey.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2020-2021 Signal Messenger, LLC
+// Copyright 2020-2021 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 

--- a/swift/Sources/SignalClient/Protocol.swift
+++ b/swift/Sources/SignalClient/Protocol.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2020-2021 Signal Messenger, LLC
+// Copyright 2020-2021 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 

--- a/swift/Sources/SignalClient/PublicKey.swift
+++ b/swift/Sources/SignalClient/PublicKey.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2020-2021 Signal Messenger, LLC
+// Copyright 2020-2021 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 

--- a/swift/Sources/SignalClient/SealedSender.swift
+++ b/swift/Sources/SignalClient/SealedSender.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2020-2021 Signal Messenger, LLC
+// Copyright 2020-2021 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 

--- a/swift/Sources/SignalClient/SealedSenderCertificates.swift
+++ b/swift/Sources/SignalClient/SealedSenderCertificates.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 Signal Messenger, LLC
+// Copyright 2021 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 

--- a/swift/Sources/SignalClient/Utils.swift
+++ b/swift/Sources/SignalClient/Utils.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2020-2021 Signal Messenger, LLC
+// Copyright 2020-2021 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 

--- a/swift/Sources/SignalClient/messages/CiphertextMessage.swift
+++ b/swift/Sources/SignalClient/messages/CiphertextMessage.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2020-2021 Signal Messenger, LLC
+// Copyright 2020-2021 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 

--- a/swift/Sources/SignalClient/messages/PlaintextContent.swift
+++ b/swift/Sources/SignalClient/messages/PlaintextContent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 Signal Messenger, LLC
+// Copyright 2021 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 

--- a/swift/Sources/SignalClient/messages/PreKeySignalMessage.swift
+++ b/swift/Sources/SignalClient/messages/PreKeySignalMessage.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2020-2021 Signal Messenger, LLC
+// Copyright 2020-2021 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 

--- a/swift/Sources/SignalClient/messages/SenderKeyDistributionMessage.swift
+++ b/swift/Sources/SignalClient/messages/SenderKeyDistributionMessage.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2020-2021 Signal Messenger, LLC
+// Copyright 2020-2021 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 

--- a/swift/Sources/SignalClient/messages/SenderKeyMessage.swift
+++ b/swift/Sources/SignalClient/messages/SenderKeyMessage.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2020-2021 Signal Messenger, LLC
+// Copyright 2020-2021 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 

--- a/swift/Sources/SignalClient/messages/SignalMessage.swift
+++ b/swift/Sources/SignalClient/messages/SignalMessage.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2020-2021 Signal Messenger, LLC
+// Copyright 2020-2021 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 

--- a/swift/Sources/SignalClient/state/PreKeyBundle.swift
+++ b/swift/Sources/SignalClient/state/PreKeyBundle.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2020-2021 Signal Messenger, LLC
+// Copyright 2020-2021 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 

--- a/swift/Sources/SignalClient/state/PreKeyRecord.swift
+++ b/swift/Sources/SignalClient/state/PreKeyRecord.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2020-2021 Signal Messenger, LLC
+// Copyright 2020-2021 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 

--- a/swift/Sources/SignalClient/state/SenderKeyRecord.swift
+++ b/swift/Sources/SignalClient/state/SenderKeyRecord.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2020-2021 Signal Messenger, LLC
+// Copyright 2020-2021 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 

--- a/swift/Sources/SignalClient/state/SessionRecord.swift
+++ b/swift/Sources/SignalClient/state/SessionRecord.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2020-2021 Signal Messenger, LLC
+// Copyright 2020-2021 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 

--- a/swift/Sources/SignalClient/state/SignedPreKeyRecord.swift
+++ b/swift/Sources/SignalClient/state/SignedPreKeyRecord.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2020-2021 Signal Messenger, LLC
+// Copyright 2020-2021 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 

--- a/swift/Tests/LinuxMain.swift
+++ b/swift/Tests/LinuxMain.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Signal Messenger, LLC
+// Copyright 2020 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 

--- a/swift/Tests/SignalClientTests/ClonableHandleOwnerTests.swift
+++ b/swift/Tests/SignalClientTests/ClonableHandleOwnerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Signal Messenger, LLC
+// Copyright 2020 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 

--- a/swift/Tests/SignalClientTests/HsmEnclaveTests.swift
+++ b/swift/Tests/SignalClientTests/HsmEnclaveTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 Signal Messenger, LLC
+// Copyright 2021 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 

--- a/swift/Tests/SignalClientTests/PublicAPITests.swift
+++ b/swift/Tests/SignalClientTests/PublicAPITests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Signal Messenger, LLC
+// Copyright 2020 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 

--- a/swift/Tests/SignalClientTests/SessionTests.swift
+++ b/swift/Tests/SignalClientTests/SessionTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Signal Messenger, LLC
+// Copyright 2020 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 

--- a/swift/Tests/SignalClientTests/TestCaseBase.swift
+++ b/swift/Tests/SignalClientTests/TestCaseBase.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Signal Messenger, LLC
+// Copyright 2020 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 

--- a/swift/Tests/SignalClientTests/TestUtils.swift
+++ b/swift/Tests/SignalClientTests/TestUtils.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2020-2021 Signal Messenger, LLC
+// Copyright 2020-2021 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 


### PR DESCRIPTION
...to have a period after "Signal Messenger, LLC."

...except for the Java sources, which still need a cleanup pass.