### PR TITLE
make doctests fail on any warnings

### DIFF
--- a/rust/protocol/src/lib.rs
+++ b/rust/protocol/src/lib.rs
@@ -1,5 +1,5 @@
 //
-// Copyright 2020-2021 Signal Messenger, LLC.
+// Copyright 2020-2022 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
@@ -16,11 +16,13 @@
 
 #![warn(clippy::unwrap_used)]
 #![deny(unsafe_code)]
-
 // TODO(https://github.com/signalapp/libsignal/issues/285): it should be an aspiration to
 // eventually warn and then error for public members without docstrings. Also see
 // https://doc.rust-lang.org/rustdoc/what-to-include.html for background.
 // #![warn(missing_docs)]
+
+// Make all doctests fail if they produce any warnings.
+#![doc(test(attr(deny(warnings))))]
 
 mod address;
 mod consts;


### PR DESCRIPTION
This is a useful setting to have on. We only have one doctest right now (for `ProtocolAddress::new()`), but this is useful when adding documentation in the constituent PRs of #467.