### PR TITLE
add docs to utils and expose `constant_time_cmp()` to consumers

### DIFF
--- a/rust/protocol/src/lib.rs
+++ b/rust/protocol/src/lib.rs
@@ -39,7 +39,7 @@ mod session;
 mod session_cipher;
 mod state;
 mod storage;
-mod utils;
+pub mod utils;
 
 use error::Result;
 


### PR DESCRIPTION
*Broken out of #287.*

This key comparison method is useful to have for downstream consumers to avoid leaking timing information when comparing bytes. If downstream consumers of the `libsignal` crate wish to implement their own structs wrapping secret bytes, they now have a clearly documented example of how to implement that.