### PR TITLE
remove Debug from SessionRecord

### DIFF
--- a/rust/protocol/src/state/session.rs
+++ b/rust/protocol/src/state/session.rs
@@ -466,7 +466,7 @@ impl From<&SessionState> for SessionStructure {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct SessionRecord {
     current_session: Option<SessionState>,
     previous_sessions: Vec<Vec<u8>>,


### PR DESCRIPTION
1. `SessionRecord` impls `Debug`, but it's not used anywhere. This removes that.
2. `PrivateKey` is *given* a `Debug` impl which avoids leaking any useful data or making elliptic curve computations.