### PR TITLE
set `imports_granularity = "Module"`

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,3 +1,3 @@
 edition = "2018"
 license_template_path = ".rustfmt.license-template"
-
+imports_granularity = "Module"

--- a/rust/attest/src/cds2.rs
+++ b/rust/attest/src/cds2.rs
@@ -7,10 +7,8 @@ use displaydoc::Display;
 use prost::Message;
 use std::convert::From;
 
-use crate::client_connection;
-use crate::dcap;
 use crate::proto::cds2;
-use crate::snow_resolver;
+use crate::{client_connection, dcap, snow_resolver};
 
 /// Error types for CDS2.
 #[derive(Display, Debug)]

--- a/rust/attest/src/hsm_enclave.rs
+++ b/rust/attest/src/hsm_enclave.rs
@@ -12,8 +12,7 @@ use log::*;
 use std::convert::From;
 use std::fmt;
 
-use crate::client_connection;
-use crate::snow_resolver;
+use crate::{client_connection, snow_resolver};
 
 /// Error types for HSM enclave.
 #[derive(Debug)]

--- a/rust/bridge/ffi/src/util.rs
+++ b/rust/bridge/ffi/src/util.rs
@@ -11,8 +11,7 @@ use libsignal_bridge::ffi::*;
 use libsignal_protocol::*;
 use signal_crypto::Error as SignalCryptoError;
 use std::ffi::CString;
-use zkgroup::ZkGroupDeserializationFailure;
-use zkgroup::ZkGroupVerificationFailure;
+use zkgroup::{ZkGroupDeserializationFailure, ZkGroupVerificationFailure};
 
 #[derive(Debug)]
 #[repr(C)]

--- a/rust/bridge/shared/macros/src/node.rs
+++ b/rust/bridge/shared/macros/src/node.rs
@@ -3,8 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-use proc_macro2::Span;
-use proc_macro2::TokenStream as TokenStream2;
+use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::*;
 use std::fmt::Display;
 use syn::spanned::Spanned;

--- a/rust/bridge/shared/src/ffi/error.rs
+++ b/rust/bridge/shared/src/ffi/error.rs
@@ -11,8 +11,7 @@ use attest::hsm_enclave::Error as HsmEnclaveError;
 use device_transfer::Error as DeviceTransferError;
 use libsignal_protocol::*;
 use signal_crypto::Error as SignalCryptoError;
-use zkgroup::ZkGroupDeserializationFailure;
-use zkgroup::ZkGroupVerificationFailure;
+use zkgroup::{ZkGroupDeserializationFailure, ZkGroupVerificationFailure};
 
 use crate::support::describe_panic;
 

--- a/rust/bridge/shared/src/hsm_enclave.rs
+++ b/rust/bridge/shared/src/hsm_enclave.rs
@@ -5,8 +5,7 @@
 
 use std::panic::RefUnwindSafe;
 
-use ::attest::client_connection;
-use ::attest::hsm_enclave;
+use ::attest::{client_connection, hsm_enclave};
 use libsignal_bridge_macros::*;
 
 use self::hsm_enclave::Result;

--- a/rust/bridge/shared/src/jni/error.rs
+++ b/rust/bridge/shared/src/jni/error.rs
@@ -11,8 +11,7 @@ use attest::hsm_enclave::Error as HsmEnclaveError;
 use device_transfer::Error as DeviceTransferError;
 use libsignal_protocol::*;
 use signal_crypto::Error as SignalCryptoError;
-use zkgroup::ZkGroupDeserializationFailure;
-use zkgroup::ZkGroupVerificationFailure;
+use zkgroup::{ZkGroupDeserializationFailure, ZkGroupVerificationFailure};
 
 use crate::support::describe_panic;
 

--- a/rust/crypto/src/lib.rs
+++ b/rust/crypto/src/lib.rs
@@ -11,9 +11,7 @@ mod hash;
 mod aes_ctr;
 mod aes_gcm;
 
-pub use {
-    aes_ctr::Aes256Ctr32,
-    aes_gcm::{Aes256GcmDecryption, Aes256GcmEncryption},
-    error::{Error, Result},
-    hash::{CryptographicHash, CryptographicMac},
-};
+pub use aes_ctr::Aes256Ctr32;
+pub use aes_gcm::{Aes256GcmDecryption, Aes256GcmEncryption};
+pub use error::{Error, Result};
+pub use hash::{CryptographicHash, CryptographicMac};

--- a/rust/device-transfer/src/lib.rs
+++ b/rust/device-transfer/src/lib.rs
@@ -9,10 +9,12 @@
 #![warn(missing_docs)]
 
 use chrono::{Datelike, Duration, Utc};
+use picky::hash::HashAlgorithm;
 use picky::key::PrivateKey;
+use picky::signature::SignatureAlgorithm;
+use picky::x509::certificate::CertificateBuilder;
+use picky::x509::date::UTCDate;
 use picky::x509::name::{DirectoryName, NameAttr};
-use picky::x509::{certificate::CertificateBuilder, date::UTCDate};
-use picky::{hash::HashAlgorithm, signature::SignatureAlgorithm};
 use std::fmt;
 
 /// Error types for device transfer.

--- a/rust/protocol/src/fingerprint.rs
+++ b/rust/protocol/src/fingerprint.rs
@@ -3,10 +3,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-use crate::proto;
-use crate::{IdentityKey, Result, SignalProtocolError};
+use crate::{proto, IdentityKey, Result, SignalProtocolError};
 use prost::Message;
-use sha2::{digest::Digest, Sha512};
+use sha2::digest::Digest;
+use sha2::Sha512;
 use std::fmt;
 use std::fmt::Write;
 use subtle::ConstantTimeEq;

--- a/rust/protocol/src/group_cipher.rs
+++ b/rust/protocol/src/group_cipher.rs
@@ -3,8 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-use crate::consts;
-use crate::crypto;
+use crate::{consts, crypto};
 
 use crate::{
     CiphertextMessageType, Context, KeyPair, ProtocolAddress, Result, SenderKeyDistributionMessage,

--- a/rust/protocol/src/identity_key.rs
+++ b/rust/protocol/src/identity_key.rs
@@ -3,8 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-use crate::proto;
-use crate::{KeyPair, PrivateKey, PublicKey, Result, SignalProtocolError};
+use crate::{proto, KeyPair, PrivateKey, PublicKey, Result, SignalProtocolError};
 
 use rand::{CryptoRng, Rng};
 use std::convert::TryFrom;

--- a/rust/protocol/src/lib.rs
+++ b/rust/protocol/src/lib.rs
@@ -43,40 +43,38 @@ mod utils;
 
 use error::Result;
 
-pub use {
-    address::{DeviceId, ProtocolAddress},
-    curve::{KeyPair, PrivateKey, PublicKey},
-    error::SignalProtocolError,
-    fingerprint::{DisplayableFingerprint, Fingerprint, ScannableFingerprint},
-    group_cipher::{
-        create_sender_key_distribution_message, group_decrypt, group_encrypt,
-        process_sender_key_distribution_message,
-    },
-    identity_key::{IdentityKey, IdentityKeyPair},
-    protocol::{
-        extract_decryption_error_message_from_serialized_content, CiphertextMessage,
-        CiphertextMessageType, DecryptionErrorMessage, PlaintextContent, PreKeySignalMessage,
-        SenderKeyDistributionMessage, SenderKeyMessage, SignalMessage,
-    },
-    ratchet::{
-        initialize_alice_session_record, initialize_bob_session_record,
-        AliceSignalProtocolParameters, BobSignalProtocolParameters,
-    },
-    sealed_sender::{
-        sealed_sender_decrypt, sealed_sender_decrypt_to_usmc, sealed_sender_encrypt,
-        sealed_sender_encrypt_from_usmc, sealed_sender_multi_recipient_encrypt,
-        sealed_sender_multi_recipient_fan_out, ContentHint, SealedSenderDecryptionResult,
-        SenderCertificate, ServerCertificate, UnidentifiedSenderMessageContent,
-    },
-    sender_keys::SenderKeyRecord,
-    session::{process_prekey, process_prekey_bundle},
-    session_cipher::{
-        message_decrypt, message_decrypt_prekey, message_decrypt_signal, message_encrypt,
-    },
-    state::{PreKeyBundle, PreKeyRecord, SessionRecord, SignedPreKeyRecord},
-    storage::{
-        Context, Direction, IdentityKeyStore, InMemIdentityKeyStore, InMemPreKeyStore,
-        InMemSenderKeyStore, InMemSessionStore, InMemSignalProtocolStore, InMemSignedPreKeyStore,
-        PreKeyStore, ProtocolStore, SenderKeyStore, SessionStore, SignedPreKeyStore,
-    },
+pub use address::{DeviceId, ProtocolAddress};
+pub use curve::{KeyPair, PrivateKey, PublicKey};
+pub use error::SignalProtocolError;
+pub use fingerprint::{DisplayableFingerprint, Fingerprint, ScannableFingerprint};
+pub use group_cipher::{
+    create_sender_key_distribution_message, group_decrypt, group_encrypt,
+    process_sender_key_distribution_message,
+};
+pub use identity_key::{IdentityKey, IdentityKeyPair};
+pub use protocol::{
+    extract_decryption_error_message_from_serialized_content, CiphertextMessage,
+    CiphertextMessageType, DecryptionErrorMessage, PlaintextContent, PreKeySignalMessage,
+    SenderKeyDistributionMessage, SenderKeyMessage, SignalMessage,
+};
+pub use ratchet::{
+    initialize_alice_session_record, initialize_bob_session_record, AliceSignalProtocolParameters,
+    BobSignalProtocolParameters,
+};
+pub use sealed_sender::{
+    sealed_sender_decrypt, sealed_sender_decrypt_to_usmc, sealed_sender_encrypt,
+    sealed_sender_encrypt_from_usmc, sealed_sender_multi_recipient_encrypt,
+    sealed_sender_multi_recipient_fan_out, ContentHint, SealedSenderDecryptionResult,
+    SenderCertificate, ServerCertificate, UnidentifiedSenderMessageContent,
+};
+pub use sender_keys::SenderKeyRecord;
+pub use session::{process_prekey, process_prekey_bundle};
+pub use session_cipher::{
+    message_decrypt, message_decrypt_prekey, message_decrypt_signal, message_encrypt,
+};
+pub use state::{PreKeyBundle, PreKeyRecord, SessionRecord, SignedPreKeyRecord};
+pub use storage::{
+    Context, Direction, IdentityKeyStore, InMemIdentityKeyStore, InMemPreKeyStore,
+    InMemSenderKeyStore, InMemSessionStore, InMemSignalProtocolStore, InMemSignedPreKeyStore,
+    PreKeyStore, ProtocolStore, SenderKeyStore, SessionStore, SignedPreKeyStore,
 };

--- a/rust/protocol/src/protocol.rs
+++ b/rust/protocol/src/protocol.rs
@@ -3,8 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-use crate::proto;
-use crate::{IdentityKey, PrivateKey, PublicKey, Result, SignalProtocolError};
+use crate::{proto, IdentityKey, PrivateKey, PublicKey, Result, SignalProtocolError};
 
 use std::convert::TryFrom;
 

--- a/rust/protocol/src/ratchet/keys.rs
+++ b/rust/protocol/src/ratchet/keys.rs
@@ -5,8 +5,7 @@
 
 use arrayref::array_ref;
 
-use crate::crypto;
-use crate::{PrivateKey, PublicKey, Result};
+use crate::{crypto, PrivateKey, PublicKey, Result};
 use std::fmt;
 
 pub(crate) struct MessageKeys {

--- a/rust/protocol/src/sealed_sender.rs
+++ b/rust/protocol/src/sealed_sender.rs
@@ -10,10 +10,7 @@ use crate::{
     SignedPreKeyStore,
 };
 
-use crate::crypto;
-use crate::curve;
-use crate::proto;
-use crate::session_cipher;
+use crate::{crypto, curve, proto, session_cipher};
 
 use aes_gcm_siv::aead::{AeadInPlace, NewAead};
 use aes_gcm_siv::Aes256GcmSiv;

--- a/rust/protocol/src/sender_keys.rs
+++ b/rust/protocol/src/sender_keys.rs
@@ -9,10 +9,9 @@ use std::convert::TryFrom;
 use itertools::Itertools;
 use prost::Message;
 
-use crate::consts;
 use crate::crypto::hmac_sha256;
 use crate::proto::storage as storage_proto;
-use crate::{PrivateKey, PublicKey, SignalProtocolError};
+use crate::{consts, PrivateKey, PublicKey, SignalProtocolError};
 
 /// A distinct error type to keep from accidentally propagating deserialization errors.
 #[derive(Debug)]

--- a/rust/protocol/src/session_cipher.rs
+++ b/rust/protocol/src/session_cipher.rs
@@ -10,10 +10,9 @@ use crate::{
 };
 
 use crate::consts::MAX_FORWARD_JUMPS;
-use crate::crypto;
 use crate::ratchet::{ChainKey, MessageKeys};
-use crate::session;
 use crate::state::{InvalidSessionError, SessionState};
+use crate::{crypto, session};
 
 use rand::{CryptoRng, Rng};
 

--- a/rust/protocol/src/state/session.rs
+++ b/rust/protocol/src/state/session.rs
@@ -13,8 +13,7 @@ use crate::ratchet::{ChainKey, MessageKeys, RootKey};
 use crate::{IdentityKey, KeyPair, PrivateKey, PublicKey, SignalProtocolError};
 
 use crate::consts;
-use crate::proto::storage::session_structure;
-use crate::proto::storage::{RecordStructure, SessionStructure};
+use crate::proto::storage::{session_structure, RecordStructure, SessionStructure};
 use crate::state::{PreKeyId, SignedPreKeyId};
 
 /// A distinct error type to keep from accidentally propagating deserialization errors.

--- a/rust/protocol/src/storage.rs
+++ b/rust/protocol/src/storage.rs
@@ -6,13 +6,11 @@
 mod inmem;
 mod traits;
 
-pub use {
-    inmem::{
-        InMemIdentityKeyStore, InMemPreKeyStore, InMemSenderKeyStore, InMemSessionStore,
-        InMemSignalProtocolStore, InMemSignedPreKeyStore,
-    },
-    traits::{
-        Context, Direction, IdentityKeyStore, PreKeyStore, ProtocolStore, SenderKeyStore,
-        SessionStore, SignedPreKeyStore,
-    },
+pub use inmem::{
+    InMemIdentityKeyStore, InMemPreKeyStore, InMemSenderKeyStore, InMemSessionStore,
+    InMemSignalProtocolStore, InMemSignedPreKeyStore,
+};
+pub use traits::{
+    Context, Direction, IdentityKeyStore, PreKeyStore, ProtocolStore, SenderKeyStore, SessionStore,
+    SignedPreKeyStore,
 };

--- a/rust/protocol/src/storage/inmem.rs
+++ b/rust/protocol/src/storage/inmem.rs
@@ -9,8 +9,7 @@ use crate::{
 };
 
 use crate::state::{PreKeyId, SignedPreKeyId};
-use crate::storage::traits;
-use crate::storage::Context;
+use crate::storage::{traits, Context};
 
 use async_trait::async_trait;
 use std::borrow::Cow;

--- a/rust/protocol/tests/support/mod.rs
+++ b/rust/protocol/tests/support/mod.rs
@@ -4,7 +4,8 @@
 //
 
 use libsignal_protocol::*;
-use rand::{rngs::OsRng, CryptoRng, Rng};
+use rand::rngs::OsRng;
+use rand::{CryptoRng, Rng};
 
 pub fn test_in_memory_protocol_store() -> Result<InMemSignalProtocolStore, SignalProtocolError> {
     let mut csprng = OsRng;

--- a/rust/zkgroup/src/api.rs
+++ b/rust/zkgroup/src/api.rs
@@ -10,5 +10,4 @@ pub mod receipts;
 
 pub mod server_params;
 
-pub use server_params::ServerPublicParams;
-pub use server_params::ServerSecretParams;
+pub use server_params::{ServerPublicParams, ServerSecretParams};

--- a/rust/zkgroup/src/api/auth.rs
+++ b/rust/zkgroup/src/api/auth.rs
@@ -10,10 +10,10 @@ pub mod auth_credential_with_pni;
 pub mod auth_credential_with_pni_response;
 
 pub use auth_credential::AuthCredential;
-pub use auth_credential_presentation::AnyAuthCredentialPresentation;
-pub use auth_credential_presentation::AuthCredentialPresentationV1;
-pub use auth_credential_presentation::AuthCredentialPresentationV2;
-pub use auth_credential_presentation::AuthCredentialWithPniPresentation;
+pub use auth_credential_presentation::{
+    AnyAuthCredentialPresentation, AuthCredentialPresentationV1, AuthCredentialPresentationV2,
+    AuthCredentialWithPniPresentation,
+};
 pub use auth_credential_response::AuthCredentialResponse;
 pub use auth_credential_with_pni::AuthCredentialWithPni;
 pub use auth_credential_with_pni_response::AuthCredentialWithPniResponse;

--- a/rust/zkgroup/src/api/auth/auth_credential_presentation.rs
+++ b/rust/zkgroup/src/api/auth/auth_credential_presentation.rs
@@ -3,13 +3,11 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-use crate::api;
 use crate::common::constants::*;
 use crate::common::errors::*;
 use crate::common::simple_types::*;
-use crate::crypto;
-use serde::Serializer;
-use serde::{Deserialize, Serialize};
+use crate::{api, crypto};
+use serde::{Deserialize, Serialize, Serializer};
 
 #[derive(Serialize, Deserialize)]
 pub struct AuthCredentialPresentationV1 {

--- a/rust/zkgroup/src/api/groups.rs
+++ b/rust/zkgroup/src/api/groups.rs
@@ -7,8 +7,6 @@ pub mod group_params;
 pub mod profile_key_ciphertext;
 pub mod uuid_ciphertext;
 
-pub use group_params::GroupMasterKey;
-pub use group_params::GroupPublicParams;
-pub use group_params::GroupSecretParams;
+pub use group_params::{GroupMasterKey, GroupPublicParams, GroupSecretParams};
 pub use profile_key_ciphertext::ProfileKeyCiphertext;
 pub use uuid_ciphertext::UuidCiphertext;

--- a/rust/zkgroup/src/api/groups/group_params.rs
+++ b/rust/zkgroup/src/api/groups/group_params.rs
@@ -5,13 +5,13 @@
 
 use std::convert::TryInto;
 
-use crate::api;
 use crate::common::constants::*;
 use crate::common::errors::*;
 use crate::common::sho::*;
 use crate::common::simple_types::*;
-use crate::crypto;
-use aead::{generic_array::GenericArray, Aead, NewAead};
+use crate::{api, crypto};
+use aead::generic_array::GenericArray;
+use aead::{Aead, NewAead};
 use aes_gcm_siv::Aes256GcmSiv;
 use serde::{Deserialize, Serialize};
 

--- a/rust/zkgroup/src/api/profiles.rs
+++ b/rust/zkgroup/src/api/profiles.rs
@@ -21,18 +21,18 @@ pub mod profile_key_version;
 pub use expiring_profile_key_credential::ExpiringProfileKeyCredential;
 pub use expiring_profile_key_credential_response::ExpiringProfileKeyCredentialResponse;
 pub use pni_credential::PniCredential;
-pub use pni_credential_presentation::AnyPniCredentialPresentation;
-pub use pni_credential_presentation::PniCredentialPresentationV1;
-pub use pni_credential_presentation::PniCredentialPresentationV2;
+pub use pni_credential_presentation::{
+    AnyPniCredentialPresentation, PniCredentialPresentationV1, PniCredentialPresentationV2,
+};
 pub use pni_credential_request_context::PniCredentialRequestContext;
 pub use pni_credential_response::PniCredentialResponse;
 pub use profile_key::ProfileKey;
 pub use profile_key_commitment::ProfileKeyCommitment;
 pub use profile_key_credential::ProfileKeyCredential;
-pub use profile_key_credential_presentation::AnyProfileKeyCredentialPresentation;
-pub use profile_key_credential_presentation::ExpiringProfileKeyCredentialPresentation;
-pub use profile_key_credential_presentation::ProfileKeyCredentialPresentationV1;
-pub use profile_key_credential_presentation::ProfileKeyCredentialPresentationV2;
+pub use profile_key_credential_presentation::{
+    AnyProfileKeyCredentialPresentation, ExpiringProfileKeyCredentialPresentation,
+    ProfileKeyCredentialPresentationV1, ProfileKeyCredentialPresentationV2,
+};
 pub use profile_key_credential_request::ProfileKeyCredentialRequest;
 pub use profile_key_credential_request_context::ProfileKeyCredentialRequestContext;
 pub use profile_key_credential_response::ProfileKeyCredentialResponse;

--- a/rust/zkgroup/src/api/profiles/pni_credential_presentation.rs
+++ b/rust/zkgroup/src/api/profiles/pni_credential_presentation.rs
@@ -3,13 +3,11 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-use crate::api;
 use crate::common::constants::*;
 use crate::common::errors::*;
 use crate::common::simple_types::*;
-use crate::crypto;
-use serde::Serializer;
-use serde::{Deserialize, Serialize};
+use crate::{api, crypto};
+use serde::{Deserialize, Serialize, Serializer};
 
 #[derive(Serialize, Deserialize)]
 pub struct PniCredentialPresentationV1 {

--- a/rust/zkgroup/src/api/profiles/pni_credential_request_context.rs
+++ b/rust/zkgroup/src/api/profiles/pni_credential_request_context.rs
@@ -3,9 +3,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-use crate::api;
 use crate::common::simple_types::*;
-use crate::crypto;
+use crate::{api, crypto};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]

--- a/rust/zkgroup/src/api/profiles/profile_key.rs
+++ b/rust/zkgroup/src/api/profiles/profile_key.rs
@@ -3,11 +3,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-use crate::api;
 use crate::common::constants::*;
 use crate::common::sho::*;
 use crate::common::simple_types::*;
-use crate::crypto;
+use crate::{api, crypto};
 use serde::{Deserialize, Serialize};
 
 #[derive(Copy, Clone, Serialize, Deserialize)]

--- a/rust/zkgroup/src/api/profiles/profile_key_credential_presentation.rs
+++ b/rust/zkgroup/src/api/profiles/profile_key_credential_presentation.rs
@@ -3,13 +3,11 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-use crate::api;
 use crate::common::constants::*;
 use crate::common::errors::*;
 use crate::common::simple_types::*;
-use crate::crypto;
-use serde::Serializer;
-use serde::{Deserialize, Serialize};
+use crate::{api, crypto};
+use serde::{Deserialize, Serialize, Serializer};
 
 #[derive(Serialize, Deserialize)]
 pub struct ProfileKeyCredentialPresentationV1 {

--- a/rust/zkgroup/src/api/profiles/profile_key_credential_request_context.rs
+++ b/rust/zkgroup/src/api/profiles/profile_key_credential_request_context.rs
@@ -3,9 +3,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-use crate::api;
 use crate::common::simple_types::*;
-use crate::crypto;
+use crate::{api, crypto};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]

--- a/rust/zkgroup/src/api/receipts/receipt_credential_presentation.rs
+++ b/rust/zkgroup/src/api/receipts/receipt_credential_presentation.rs
@@ -5,12 +5,8 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::crypto;
 use crate::crypto::receipt_struct::ReceiptStruct;
-use crate::ReceiptLevel;
-use crate::ReceiptSerialBytes;
-use crate::ReservedBytes;
-use crate::Timestamp;
+use crate::{crypto, ReceiptLevel, ReceiptSerialBytes, ReservedBytes, Timestamp};
 
 #[derive(Serialize, Deserialize)]
 pub struct ReceiptCredentialPresentation {

--- a/rust/zkgroup/src/api/receipts/receipt_credential_request_context.rs
+++ b/rust/zkgroup/src/api/receipts/receipt_credential_request_context.rs
@@ -5,9 +5,8 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::api;
 use crate::common::simple_types::*;
-use crate::crypto;
+use crate::{api, crypto};
 
 #[derive(Serialize, Deserialize)]
 pub struct ReceiptCredentialRequestContext {

--- a/rust/zkgroup/src/api/server_params.rs
+++ b/rust/zkgroup/src/api/server_params.rs
@@ -5,12 +5,11 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::api;
 use crate::common::constants::*;
 use crate::common::errors::*;
 use crate::common::sho::*;
 use crate::common::simple_types::*;
-use crate::crypto;
+use crate::{api, crypto};
 
 #[derive(Copy, Clone, Serialize, Deserialize)]
 pub struct ServerSecretParams {

--- a/rust/zkgroup/src/crypto/credentials.rs
+++ b/rust/zkgroup/src/crypto/credentials.rs
@@ -15,8 +15,9 @@ use crate::common::sho::*;
 use crate::common::simple_types::*;
 use crate::crypto::receipt_struct::ReceiptStruct;
 use crate::crypto::timestamp_struct::TimestampStruct;
-use crate::crypto::uid_struct;
-use crate::crypto::{profile_key_credential_request, receipt_credential_request, receipt_struct};
+use crate::crypto::{
+    profile_key_credential_request, receipt_credential_request, receipt_struct, uid_struct,
+};
 use crate::{
     NUM_AUTH_CRED_ATTRIBUTES, NUM_PROFILE_KEY_CRED_ATTRIBUTES, NUM_RECEIPT_CRED_ATTRIBUTES,
 };

--- a/rust/zkgroup/src/crypto/profile_key_encryption.rs
+++ b/rust/zkgroup/src/crypto/profile_key_encryption.rs
@@ -14,9 +14,7 @@ use curve25519_dalek::ristretto::RistrettoPoint;
 use curve25519_dalek::scalar::Scalar;
 use serde::{Deserialize, Serialize};
 
-use curve25519_dalek::subtle::Choice;
-use curve25519_dalek::subtle::ConditionallySelectable;
-use curve25519_dalek::subtle::ConstantTimeEq;
+use curve25519_dalek::subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
 use lazy_static::lazy_static;
 

--- a/rust/zkgroup/src/crypto/profile_key_struct.rs
+++ b/rust/zkgroup/src/crypto/profile_key_struct.rs
@@ -11,8 +11,7 @@ use crate::common::simple_types::*;
 use curve25519_dalek::ristretto::RistrettoPoint;
 use serde::{Deserialize, Serialize};
 
-use curve25519_dalek::subtle::Choice;
-use curve25519_dalek::subtle::ConditionallySelectable;
+use curve25519_dalek::subtle::{Choice, ConditionallySelectable};
 
 #[derive(Copy, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct ProfileKeyStruct {

--- a/rust/zkgroup/src/crypto/proofs.rs
+++ b/rust/zkgroup/src/crypto/proofs.rs
@@ -16,16 +16,12 @@ use crate::common::constants::*;
 use crate::common::errors::*;
 use crate::common::sho::*;
 use crate::common::simple_types::*;
-use crate::crypto::credentials;
-use crate::crypto::profile_key_commitment;
-use crate::crypto::profile_key_credential_request;
-use crate::crypto::profile_key_encryption;
-use crate::crypto::profile_key_struct;
-use crate::crypto::receipt_credential_request;
 use crate::crypto::receipt_struct::ReceiptStruct;
 use crate::crypto::timestamp_struct::TimestampStruct;
-use crate::crypto::uid_encryption;
-use crate::crypto::uid_struct;
+use crate::crypto::{
+    credentials, profile_key_commitment, profile_key_credential_request, profile_key_encryption,
+    profile_key_struct, receipt_credential_request, uid_encryption, uid_struct,
+};
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct AuthCredentialIssuanceProof {

--- a/rust/zkgroup/src/crypto/receipt_credential_request.rs
+++ b/rust/zkgroup/src/crypto/receipt_credential_request.rs
@@ -12,8 +12,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::common::sho::Sho;
 use crate::crypto::credentials;
-use crate::crypto::credentials::BlindedReceiptCredential;
-use crate::crypto::credentials::ReceiptCredential;
+use crate::crypto::credentials::{BlindedReceiptCredential, ReceiptCredential};
 use crate::ReceiptSerialBytes;
 
 #[derive(Copy, Clone, PartialEq, Serialize, Deserialize)]

--- a/rust/zkgroup/src/crypto/receipt_struct.rs
+++ b/rust/zkgroup/src/crypto/receipt_struct.rs
@@ -7,9 +7,7 @@ use curve25519_dalek::scalar::Scalar;
 use serde::{Deserialize, Serialize};
 
 use crate::common::sho::Sho;
-use crate::common::simple_types::ReceiptLevel;
-use crate::common::simple_types::ReceiptSerialBytes;
-use crate::common::simple_types::Timestamp;
+use crate::common::simple_types::{ReceiptLevel, ReceiptSerialBytes, Timestamp};
 
 /// The full set of information known by the client after receiving the credential response from
 /// the issuing server. It will all be shared with the credential presentation. Initially the

--- a/rust/zkgroup/tests/receipt_flow.rs
+++ b/rust/zkgroup/tests/receipt_flow.rs
@@ -5,10 +5,9 @@
 
 use zkgroup::api::receipts::ReceiptCredentialPresentation;
 use zkgroup::common::sho::Sho;
-use zkgroup::crypto::credentials;
 use zkgroup::crypto::proofs::{ReceiptCredentialIssuanceProof, ReceiptCredentialPresentationProof};
-use zkgroup::crypto::receipt_credential_request;
 use zkgroup::crypto::receipt_struct::ReceiptStruct;
+use zkgroup::crypto::{credentials, receipt_credential_request};
 use zkgroup::{
     RandomnessBytes, ReceiptLevel, ReceiptSerialBytes, ServerSecretParams, Timestamp,
     RANDOMNESS_LEN, RECEIPT_SERIAL_LEN,


### PR DESCRIPTION
Upon the suggestion of this comment (https://github.com/signalapp/libsignal/pull/287#discussion_r647029094), we modify our rustfmt config to splat out imports by each module.