### PR TITLE
Change getSender method of SenderCertificate to always return the UUID

### DIFF
--- a/java/client/src/main/java/org/signal/libsignal/metadata/certificate/SenderCertificate.java
+++ b/java/client/src/main/java/org/signal/libsignal/metadata/certificate/SenderCertificate.java
@@ -64,7 +64,7 @@ public class SenderCertificate implements NativeHandleGuard.Owner {
   }
 
   public String getSender() {
-    return getSenderE164().orElseGet(this::getSenderUuid);
+    return this.getSenderUuid();
   }
 
   public long getExpiration() {

--- a/java/client/src/test/java/org/signal/libsignal/metadata/SealedSessionCipherTest.java
+++ b/java/client/src/test/java/org/signal/libsignal/metadata/SealedSessionCipherTest.java
@@ -313,7 +313,7 @@ public class SealedSessionCipherTest extends TestCase {
       bobCipher.decrypt(new CertificateValidator(trustRoot.getPublicKey()), bobMessage, 31335);
       fail("should have thrown");
     } catch (ProtocolNoSessionException e) {
-      assertEquals(e.getSender(), "+14151111111");
+      assertEquals(e.getSender(), "9d0652a3-dcc3-4d11-975f-74d61598733f");
       assertEquals(e.getSenderDevice(), 1);
       assertEquals(e.getContentHint(), UnidentifiedSenderMessageContent.CONTENT_HINT_RESENDABLE);
       assertEquals(Hex.toStringCondensed(e.getGroupId().get()), Hex.toStringCondensed(new byte[]{42, 1}));


### PR DESCRIPTION
Currently the only user of this method is the [ProtcolException constructor](https://github.com/signalapp/libsignal/blob/b5d48df116c6f0dfb1fb8ab2365a0be63c44be3f/java/client/src/main/java/org/signal/libsignal/metadata/ProtocolException.java#L23), when an UnidentifiedSenderMessageContent is present. All other instances of ProtocolException already use the sender's UUID as sender. So it would be good to have this consistent.

Also brings this in line with similar methods, like [getSourceIdentifier](https://github.com/signalapp/Signal-Android/blob/0cae15b7fdf1b1baa77a81322dd62d93d575d567/libsignal/service/src/main/java/org/whispersystems/signalservice/api/messages/SignalServiceEnvelope.java#L147) on SignalServiceEnvelope in the Android app.