### PR TITLE
lean on stable Ordering repr(i8)

### DIFF
--- a/rust/bridge/shared/src/protocol.rs
+++ b/rust/bridge/shared/src/protocol.rs
@@ -1,5 +1,5 @@
 //
-// Copyright 2021-2022 Signal Messenger, LLC.
+// Copyright 2021-2023 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
@@ -117,11 +117,8 @@ bridge_get!(ProtocolAddress::name as Name -> &str, ffi = "address_get_name");
 
 #[bridge_fn(ffi = "publickey_compare", node = "PublicKey_Compare")]
 fn ECPublicKey_Compare(key1: &PublicKey, key2: &PublicKey) -> i32 {
-    match key1.cmp(key2) {
-        std::cmp::Ordering::Less => -1,
-        std::cmp::Ordering::Equal => 0,
-        std::cmp::Ordering::Greater => 1,
-    }
+    // Rust encodes Ordering::{Less,Equal,Greater} as {-1,0,+1}.
+    key1.cmp(key2) as i32
 }
 
 #[bridge_fn(ffi = "publickey_verify", node = "PublicKey_Verify")]


### PR DESCRIPTION
- *Context:* In https://github.com/dalek-cryptography/subtle/pull/98#issuecomment-1371252490 I make the case to the `subtle` crate that `libsignal` can remove our hand-rolled `constant_time_cmp()` if they support `ConstantTimeOrd` upstream via my change.
- While implementing that for the `subtle` project, I learned that you can lean on [`Ordering`](https://doc.rust-lang.org/core/cmp/enum.Ordering.html) having `repr(i8)` to avoid uses of `match`. In dalek-cryptography/subtle#98, this is used to impl `subtle::ConditionallySelectable` for `Ordering` by delegating to the impl for `i8`.
- It turns out we can avoid a `match` here too in libsignal's FFI method to compare public keys, since our encoding of `Ordering` into `i<whatever>` in `ECPublicKey_Compare` matches the one from the rust stdlib.