### PR TITLE
Add unidentified access key derivation method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2233,4 +2233,5 @@ dependencies = [
  "rand 0.7.3",
  "serde",
  "sha2",
+ "signal-crypto",
 ]

--- a/rust/zkgroup/Cargo.toml
+++ b/rust/zkgroup/Cargo.toml
@@ -13,6 +13,7 @@ license = "AGPL-3.0-only"
 
 [dependencies]
 poksho = { path = "../poksho" }
+signal-crypto = { path = "../crypto" }
 
 bincode = "1.2.1"
 serde = { version = "1.0.106", features = ["derive"] }


### PR DESCRIPTION
We've been implementing our own access key derivation function for a while now in libsignal-service, currently [as an extention trait](https://github.com/whisperfish/libsignal-service-rs/pull/195/), but it feels a bit weird not to have it in here.


Things up for discussion:

- I assume you probably want a wrapper struct around it.
- I think you maybe want to expose this to iOS/Android/TS too, such that you can drop the individual implementations in Java/Swift/TS.
- For the known-answer tests, I've generated a few using our own pre-existing (and working) implementation, but feel free to add some of your own to make sure.
- This makes zkgroup dependent on signal-crypto, because of the GCM implementation. It might be worth dropping that in favour of the pre-existing aes-gcm crate, or something entirely different.

This is a suggestion PR, so feel free to suggest alternative approaches :)