### PR TITLE
Fuzz test fixes related to pre_key_id and archived sessions count

### DIFF
--- a/rust/protocol/fuzz/fuzz_targets/interaction.rs
+++ b/rust/protocol/fuzz/fuzz_targets/interaction.rs
@@ -222,10 +222,12 @@ fuzz_target!(|data: (u64, &[u8])| {
             };
             match action >> 1 {
                 0 => {
-                    if me.archive_count < 40 {
+                    if me.archive_count + them.archive_count < 40 {
                         // Only archive if it can't result in old sessions getting expired.
                         // We're not testing that.
                         me.archive_session(&them.address).await
+                    } else {
+                        info!("{}: archiving LIMITED at {}/{}", me.name, me.archive_count, them.archive_count);
                     }
                 }
                 1..=32 => me.receive_messages(&them.address, &mut csprng).await,

--- a/rust/protocol/fuzz/fuzz_targets/interaction.rs
+++ b/rust/protocol/fuzz/fuzz_targets/interaction.rs
@@ -222,7 +222,15 @@ fuzz_target!(|data: (u64, &[u8])| {
             };
             match action >> 1 {
                 0 => {
-                    if me.archive_count + them.archive_count < 40 {
+                    let mut estimated_prev_states = 0;
+                    // The set of previous session states grows in two ways:
+                    // 1) The current session state of "me" is archived explicitly.
+                    estimated_prev_states += me.archive_count;
+                    // 2) A pre-key message is received from "them" and displaces the
+                    //    current session state. They may send one pre-key message initially.
+                    //    Additional pre-key messages from "them" follow explicit archiving.
+                    estimated_prev_states += 1 + them.archive_count;
+                    if estimated_prev_states < 40 {
                         // Only archive if it can't result in old sessions getting expired.
                         // We're not testing that.
                         me.archive_session(&them.address).await


### PR DESCRIPTION
Fixes #514 

Adopts idea from #514 about limiting the sum `me.archive_count + them.archive_count < 40`. Seems reasonable that any session archive by A would require B to archive a session state if those new messages are received.

I also observed some failures where either `pre_key_id == 0` or duplicate `pre_key_id` would confuse the message decryption.

The consumption of random numbers in `process_pre_key` is kept in case there are pre-existing corpora that rely on that behavior. Could probably be eliminated...