### PR TITLE
Add Automatic-Module-Name attribute to jar manifest

### DIFF
--- a/java/client/build.gradle
+++ b/java/client/build.gradle
@@ -46,6 +46,12 @@ java {
     withJavadocJar()
 }
 
+tasks.named('jar') {
+    manifest {
+        attributes('Automatic-Module-Name': 'org.signal.libsignal')
+    }
+}
+
 processResources {
     // TODO: Build a different variant of the JNI library for server.
     dependsOn ':makeJniLibrariesDesktop'


### PR DESCRIPTION
This allows using the libraries from java modules.

https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_modular_auto