### PR TITLE
Use explicit rev for dalek

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,7 +680,7 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "3.2.1"
-source = "git+https://github.com/signalapp/curve25519-dalek?branch=lizard2#4f0aa6653c51598daa0a2f53b8ba54ce0eedfbdd"
+source = "git+https://github.com/signalapp/curve25519-dalek?rev=4f0aa6653c51598daa0a2f53b8ba54ce0eedfbdd#4f0aa6653c51598daa0a2f53b8ba54ce0eedfbdd"
 dependencies = [
  "byteorder",
  "digest 0.9.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ resolver = "2" # so that our dev-dependency features don't leak into products
 
 [patch.crates-io]
 # Use our fork of curve25519-dalek for eventual zkgroup support.
-curve25519-dalek = { git = 'https://github.com/signalapp/curve25519-dalek', branch = 'lizard2' }
+curve25519-dalek = { git = 'https://github.com/signalapp/curve25519-dalek', rev = "4f0aa6653c51598daa0a2f53b8ba54ce0eedfbdd" }
 boring = { git = 'https://github.com/signalapp/boring', branch = 'libsignal'}
 
 [profile.dev.package.argon2]

--- a/rust/zkgroup/Cargo.toml
+++ b/rust/zkgroup/Cargo.toml
@@ -36,7 +36,7 @@ rand = { version = "0.7.3", optional = true }
 features = ["serde"]
 version = "3.0.0"
 git = "https://github.com/signalapp/curve25519-dalek.git"
-branch = "lizard2"
+rev = "4f0aa6653c51598daa0a2f53b8ba54ce0eedfbdd"
 
 
 [dev-dependencies]


### PR DESCRIPTION
Using an explicit rev makes `zkgroup` importable now that dalek has a 4.0.0 release. It becomes unpatchable without the rev since you'll just get 4.0.0 and an unresolveable dependency availability issue.

Besides, explicit revs are a bit more stable than branch revs, although the lock-file is checked in so it doesn't matter that much