### PR TITLE
Fix wrong shared secret length in KEM

### DIFF
--- a/rust/protocol/src/kem.rs
+++ b/rust/protocol/src/kem.rs
@@ -118,7 +118,7 @@ impl<T: Parameters> DynParameters for T {
     }
 
     fn shared_secret_length(&self) -> usize {
-        Self::SECRET_KEY_LENGTH
+        Self::SHARED_SECRET_LENGTH
     }
 
     fn generate(&self) -> (KeyMaterial<Public>, KeyMaterial<Secret>) {


### PR DESCRIPTION
The shared_secret_length function returned the wrong length.