### PR TITLE
usernames: Enable `digest` feature on `curve25519-dalek` dependency

### DIFF
--- a/rust/usernames/Cargo.toml
+++ b/rust/usernames/Cargo.toml
@@ -15,7 +15,7 @@ license = "AGPL-3.0-only"
 poksho = { path = "../poksho" }
 signal-crypto = { path = "../crypto" }
 
-curve25519-dalek = "4.0"
+curve25519-dalek = { version = "4.0", features = ["digest"] }
 hkdf = "0.12"
 hmac = "0.12"
 sha2 = "0.10"


### PR DESCRIPTION
Fixes this compile error:
```
error[E0599]: no function or associated item named `from_hash` found for struct `Scalar` in the current scope
   --> /home/user/.cargo/git/checkouts/libsignal-e5ca3c64ee2f7cbe/f980fcc/rust/usernames/src/username.rs:218:16
    |
218 |     Ok(Scalar::from_hash(hash))
    |                ^^^^^^^^^ function or associated item not found in `Scalar`
    |
note: if you're trying to build a new `Scalar` consider using one of the following associated functions:
      Scalar::from_bytes_mod_order
      Scalar::from_bytes_mod_order_wide
      Scalar::batch_invert
   --> /home/user/.cargo/registry/src/index.crates.io-6f17d22bba15001f/curve25519-dalek-4.1.1/src/scalar.rs:239:5
    |
239 |     pub fn from_bytes_mod_order(bytes: [u8; 32]) -> Scalar {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
252 |     pub fn from_bytes_mod_order_wide(input: &[u8; 64]) -> Scalar {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
790 |     pub fn batch_invert(inputs: &mut [Scalar]) -> Scalar {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

For more information about this error, try `rustc --explain E0599`.
error: could not compile `usernames` (lib) due to 1 previous error
```