### PR TITLE
bridge: only use cpufeatures on iOS

### DIFF
--- a/rust/bridge/ffi/Cargo.toml
+++ b/rust/bridge/ffi/Cargo.toml
@@ -32,8 +32,10 @@ signal-pin = { path = "../../pin" }
 signal-media = { path = "../../media" }
 libsignal-bridge = { path = "../shared", features = ["ffi"] }
 async-trait = "0.1.41"
-cpufeatures = "0.2.1" # Make sure iOS gets optimized crypto.
 futures-util = "0.3"
 rand = "0.8"
 log = { version = "0.4", features = ["release_max_level_info"] }
 log-panics = { version = "2.1.0", features = ["with-backtrace"] }
+
+[target.aarch64-apple-ios.dependencies]
+cpufeatures = "0.2.1" # Make sure iOS gets optimized crypto.


### PR DESCRIPTION
The `cpufeatures` crate only supports a limited number of architectures, and since a comment explicitly stated that this is for iOS optimization, and since [the same is done for jni](https://github.com/signalapp/libsignal/blob/main/rust/bridge/jni/Cargo.toml#L31), I think this is a sensible change.