### PR TITLE
Fixed use of a wrong function

### DIFF
--- a/swift/Sources/LibSignalClient/state/PreKeyBundle.swift
+++ b/swift/Sources/LibSignalClient/state/PreKeyBundle.swift
@@ -193,7 +193,7 @@ public class PreKeyBundle: NativeHandleOwner {
         let prekey_id = withNativeHandle { nativeHandle in
             failOnError {
                 try invokeFnReturningInteger {
-                    signal_pre_key_bundle_get_signed_pre_key_id($0, nativeHandle)
+                    signal_pre_key_bundle_get_pre_key_id($0, nativeHandle)
                 }
             }
         }


### PR DESCRIPTION
PreKeyBundle methods preKeyId and signedPreKeyId used the same function call to signal_pre_key_bundle_get_signed_pre_key_id, so they returned same values. Fixed this, so that preKeyId would use signal_pre_key_bundle_get_pre_key_id. 