### PR TITLE
Fix class loading issue with GraalVM

### DIFF
--- a/rust/bridge/jni/src/lib.rs
+++ b/rust/bridge/jni/src/lib.rs
@@ -50,10 +50,15 @@ pub unsafe extern "C" fn Java_org_signal_libsignal_internal_Native_initializeLib
     class: JClass<'local>,
 ) {
     run_ffi_safe(&mut env, |env| {
+        #[cfg(target_os = "android")]
         save_class_loader(env, &class)?;
 
         #[cfg(target_os = "android")]
         set_up_rustls_platform_verifier(env, class)?;
+
+        // Silence the unused variable warning on non-Android.
+        _ = class;
+        _ = env;
 
         Ok(())
     })


### PR DESCRIPTION
Only use the class loader cache workaround on Android.

Fixes #576