### PR TITLE
Convenience methods for ServiceId

### DIFF
--- a/rust/core/src/address.rs
+++ b/rust/core/src/address.rs
@@ -271,6 +271,11 @@ impl ServiceId {
             ServiceId::Pni(pni) => pni.into(),
         }
     }
+
+    /// Constructs a [ProtocolAddress] from this service ID and a device ID.
+    pub fn to_protocol_address(self, device_id: DeviceId) -> ProtocolAddress {
+        ProtocolAddress::new(self.service_id_string(), device_id)
+    }
 }
 
 impl fmt::Debug for ServiceId {

--- a/rust/core/src/address.rs
+++ b/rust/core/src/address.rs
@@ -273,7 +273,7 @@ impl ServiceId {
     }
 
     /// Constructs a [ProtocolAddress] from this service ID and a device ID.
-    pub fn to_protocol_address(self, device_id: DeviceId) -> ProtocolAddress {
+    pub fn to_protocol_address(&self, device_id: DeviceId) -> ProtocolAddress {
         ProtocolAddress::new(self.service_id_string(), device_id)
     }
 }


### PR DESCRIPTION
These are some convenience methods that make working with ServiceId and ProtocolAddress a tiny bit more convenient. I haven't been able to find use cases in the libsignal-protocol stack itself, but I haven't looked very thoroughly either.