### PR TITLE
ffi change: Enable SessionRecord_NewFresh, change to cdylib

### DIFF
--- a/rust/bridge/ffi/Cargo.toml
+++ b/rust/bridge/ffi/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 
 [lib]
 name = "signal_ffi"
-crate-type = ["staticlib"]
+crate-type = ["cdylib"]
 
 [features]
 # Testing the Swift side of this requires compiling with SIGNAL_MEDIA_SUPPORTED enabled for both Swift and C:

--- a/rust/bridge/shared/src/protocol.rs
+++ b/rust/bridge/shared/src/protocol.rs
@@ -925,7 +925,7 @@ fn CiphertextMessage_FromPlaintextContent(m: &PlaintextContent) -> CiphertextMes
     CiphertextMessage::PlaintextContent(m.clone())
 }
 
-#[bridge_fn(ffi = false, node = false)]
+#[bridge_fn(node = false)]
 fn SessionRecord_NewFresh() -> SessionRecord {
     SessionRecord::new_fresh()
 }


### PR DESCRIPTION
Hi,

I am planning to wrap `libsignal` using other languages through FFI and noticed that the `rust/bridge/ffi` part seems to be unmaintained, with the focus primarily on Java/Node/Swift. In the package `ffi`, the `crate-type` is defined as `staticlib`, which doesn't seem to be the usual way FFI is used. Moreover, some methods are not exported only in `ffi` package. I would like to propose changes in this regard, thank you.

For the first simple change, I would like to export `SessionRecord_NewFresh` so that other programming language wrappers for libsignal can construct an instance from scratch. This makes it easier to write test cases for `SessionRecord`.

Additionally, I would like to know if this project accepts external PRs. Does the adjacent storage-service project also accept PRs?