### PR TITLE
Add Crates.io publishing CI action

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1,0 +1,34 @@
+name: Publish to crates.io
+
+on:
+  workflow_dispatch:
+  push:
+  release:
+
+jobs:
+  publish:
+    environment: release
+    
+    permissions:
+      # Needed for rust-lang/crates-io-auth-action
+      id-token: write
+
+    runs-on: ubuntu-latest
+
+    needs: changes
+
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - uses: rust-lang/crates-io-auth-action@e919bc7605cde86df457cf5b93c5e103838bd879 # v1.0.1
+        id: auth
+
+      - run: cargo publish --dry-run
+        if: ${{ github.event_name != 'release' && github.event_name != 'workflow_dispatch' }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+
+      - run: cargo publish
+        if: ${{ github.event_name == 'release' || github.event_name == 'workflow_dispatch' }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
This action also does a dry run if the action isn't triggered manually or from a release.

I hope this PR is not too presumptuous, but I was hoping that having this CI action done for you would nudge you into closing #490.

What's missing here are things I can't do for you, mainly ensuring the requirements from [the publishing docs](https://doc.rust-lang.org/book/ch14-02-publishing-to-crates-io.html) are met (I think it's just missing you creating an account, but I'm not 100% sure), as well as [the docs from Trusted Publishing](https://blog.rust-lang.org/2025/07/11/crates-io-development-update-2025-07/#trusted-publishing) (mainly adding this repo for the publishing).

Let me know if there's anything I can do to make this easier for you!