### PR TITLE
Signal lib extension in Go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ java/server/src/main/resources/*.dll
 Brewfile.lock.json
 
 __pycache__
+
+signal-c-binding/include/signal_c_binding.h

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4742,6 +4742,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-c-binding"
+version = "0.1.0"
+dependencies = [
+ "futures",
+ "libsignal-core",
+ "libsignal-protocol",
+ "log",
+ "rand 0.9.2",
+]
+
+[[package]]
 name = "signal-crypto"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     "rust/bridge/jni/impl",
     "rust/bridge/jni/testing",
     "rust/bridge/node",
+    "signal-c-binding",
 ]
 default-members = [
     "rust/crypto",

--- a/examples/go/.gitignore
+++ b/examples/go/.gitignore
@@ -1,0 +1,2 @@
+.gocache/*
+signalexample

--- a/examples/go/README.md
+++ b/examples/go/README.md
@@ -1,0 +1,52 @@
+# Go FFI Example
+
+This directory contains Go helpers that exercise the `signal-c-binding` shim:
+
+- `go run ./examples/go` keeps the original in-process demo.
+- `go run ./examples/go/cmd/server` starts a small HTTP server with registration, login, pre-key storage, and message queues.
+- `go run ./examples/go/cmd/client` is an interactive CLI you can run for each user/device to register, log in, and exchange messages through the server.
+
+## Prerequisites
+
+1. Build the Rust shim (outputs `libsignal_c_binding.a` in `target/release`):
+   ```bash
+   cargo build -p signal-c-binding --release
+   ```
+2. Run the Go example with an in-repo build cache to avoid `$HOME` permission issues:
+   ```bash
+   GOCACHE=$(pwd)/examples/go/.gocache go run ./examples/go
+   ```
+
+The program prints the ciphertext type/size and the decrypted plaintext once the round-trip succeeds.
+
+## Running the HTTP server demo
+
+1. In one terminal start the server (it listens on `:8080` by default):
+   ```bash
+   GOCACHE=$(pwd)/examples/go/.gocache go run ./examples/go/cmd/server
+   ```
+2. In two additional terminals run the interactive clients, one per user/device. For example:
+   ```bash
+   # Terminal 2 – register & log in Alice/device 1
+   GOCACHE=$(pwd)/examples/go/.gocache go run ./examples/go/cmd/client \
+     --server http://localhost:8080
+
+   # Terminal 3 – register & log in Bob/device 1
+   GOCACHE=$(pwd)/examples/go/.gocache go run ./examples/go/cmd/client \
+     --server http://localhost:8080
+   ```
+
+Once running, every client instance offers a small menu:
+
+- `1` register – choose a username/password pair.
+- `2` login – authenticate, pick a device ID (1–127), and publish your bundle.
+- `3` exit.
+
+After logging in the prompt switches to `session>` with the following commands:
+
+- `send <user> <device> <message>` – fetch that peer/device bundle if needed, establish a session, and push an encrypted Signal message through the server.
+- `sendall <user> <message>` – send the plaintext to every device of that peer the client has discovered so far (devices learned from prior messages or sends).
+- `refresh` – pull pending ciphertexts for the logged-in device, decrypt them, and print `[peer] message` lines.
+- `logout` – tear down the local session and return to the top-level menu.
+
+Run two client instances side-by-side, register/login with different users, and use `send`/`refresh` to watch the two-way Signal conversation flow through the shared server.

--- a/examples/go/cmd/client/README.md
+++ b/examples/go/cmd/client/README.md
@@ -1,0 +1,55 @@
+# Signal Demo CLI Client
+
+This command-line client drives the demo HTTP server in
+`examples/go/cmd/server`. It manages registration, login, bundle uploads, and
+encrypted messaging using the Go FFI wrappers for the Signal protocol.
+
+## Prerequisites
+
+1. Build the Rust `signal-c-binding` shim so the Go bindings can link against
+   it:
+   ```bash
+   cargo build -p signal-c-binding --release
+   ```
+2. Export a build cache inside the repository (optional but avoids sandbox
+   issues):
+   ```bash
+   export GOCACHE=$(pwd)/examples/go/.gocache
+   ```
+3. Start the demo server in another terminal:
+   ```bash
+   $GOCACHE go run ./examples/go/cmd/server --listen :8080
+   ```
+
+## Running the Client
+
+Launch the interactive CLI (it defaults to `http://localhost:8080`):
+
+```bash
+$GOCACHE go run ./examples/go/cmd/client --server http://localhost:8080
+```
+
+Multiple instances can run simultaneously—start one per user/device.
+
+## Top-Level Menu
+
+After startup you can choose:
+
+- `register` – create a username/password.
+- `login` – authenticate, choose a device ID (1–127), and publish your bundle.
+- `exit` – quit the program.
+
+## Session Commands
+
+Successful login drops you into a `session>` prompt. Available commands:
+
+- `send <user> <device> <message>` – ensure the peer bundle is fetched, then
+  encrypt and queue the message for that specific device.
+- `sendall <user> <message>` – broadcast to every known device for the peer
+  (devices are learned from previous exchanges).
+- `refresh` – pull pending ciphertexts from the server, decrypt them locally,
+  and print `[peer/device] message` lines.
+- `logout` – close the session and return to the main menu.
+
+Use two terminals to log in as different users and experiment with encrypted
+round-trips through the server.

--- a/examples/go/cmd/client/main.go
+++ b/examples/go/cmd/client/main.go
@@ -1,0 +1,478 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"signalexample/ffi"
+	"signalexample/transport"
+)
+
+const registrationID = 2024
+
+type registerRequest struct {
+	Name     string `json:"name"`
+	Password string `json:"password"`
+}
+
+type loginRequest struct {
+	Name     string `json:"name"`
+	Password string `json:"password"`
+	DeviceID uint32 `json:"device_id"`
+}
+
+type loginResponse struct {
+	Token string `json:"token"`
+}
+
+type protocolAddressJSON struct {
+	Name     string `json:"name"`
+	DeviceID uint32 `json:"device_id"`
+}
+
+type sendRequest struct {
+	From       protocolAddressJSON `json:"from"`
+	To         protocolAddressJSON `json:"to"`
+	CipherType uint8               `json:"cipher_type"`
+	Payload    []byte              `json:"payload"`
+}
+
+type queuedMessage struct {
+	From       protocolAddressJSON `json:"from"`
+	CipherType uint8               `json:"cipher_type"`
+	Payload    []byte              `json:"payload"`
+	Timestamp  int64               `json:"timestamp"`
+}
+
+type sessionState struct {
+	token       string
+	username    string
+	deviceID    uint32
+	client      *ffi.Client
+	selfAddr    ffi.Address
+	peerAddrs   map[string]ffi.Address
+	peerReady   map[string]bool
+	peerDevices map[string]map[uint32]struct{}
+	httpClient  *http.Client
+	serverURL   string
+}
+
+func main() {
+	serverFlag := flag.String("server", "http://localhost:8080", "demo server base URL")
+	flag.Parse()
+
+	httpClient := &http.Client{Timeout: 10 * time.Second}
+	reader := bufio.NewReader(os.Stdin)
+
+	for {
+		fmt.Println("Select an option:")
+		fmt.Println("1) register")
+		fmt.Println("2) login")
+		fmt.Println("3) exit")
+		choice := strings.TrimSpace(readLine(reader, "> "))
+		switch choice {
+		case "1", "register":
+			handleRegister(reader, httpClient, *serverFlag)
+		case "2", "login":
+			if err := handleLogin(reader, httpClient, *serverFlag); err != nil {
+				log.Printf("login error: %v", err)
+			}
+		case "3", "exit", "quit":
+			fmt.Println("Goodbye")
+			return
+		default:
+			fmt.Println("Unknown choice. Please enter 1, 2, or 3.")
+		}
+	}
+}
+
+func handleRegister(reader *bufio.Reader, httpClient *http.Client, server string) {
+	name := strings.TrimSpace(readLine(reader, "Choose a username: "))
+	password := strings.TrimSpace(readLine(reader, "Choose a password: "))
+	if name == "" || password == "" {
+		fmt.Println("Username and password must not be empty.")
+		return
+	}
+	req := registerRequest{Name: name, Password: password}
+	if err := postJSON(httpClient, fmt.Sprintf("%s/v1/register", server), req, ""); err != nil {
+		fmt.Printf("Registration failed: %v\n", err)
+		return
+	}
+	fmt.Printf("Registered user %s. You can now log in.\n", name)
+}
+
+func handleLogin(reader *bufio.Reader, httpClient *http.Client, server string) error {
+	name := strings.TrimSpace(readLine(reader, "Username: "))
+	password := strings.TrimSpace(readLine(reader, "Password: "))
+	deviceID, err := promptDeviceID(reader)
+	if err != nil {
+		return err
+	}
+
+	var loginResp loginResponse
+	if err := postAndDecode(httpClient, fmt.Sprintf("%s/v1/login", server), loginRequest{
+		Name:     name,
+		Password: password,
+		DeviceID: deviceID,
+	}, "", &loginResp); err != nil {
+		return err
+	}
+	if loginResp.Token == "" {
+		return fmt.Errorf("server returned empty token")
+	}
+	fmt.Printf("Logged in as %s (device %d).\n", name, deviceID)
+
+	client, err := ffi.NewClient(name, registrationID, deviceID)
+	if err != nil {
+		return fmt.Errorf("create client: %w", err)
+	}
+
+	selfAddr, err := ffi.NewAddress(name, deviceID)
+	if err != nil {
+		client.Close()
+		return fmt.Errorf("create address: %w", err)
+	}
+
+	state := &sessionState{
+		token:       loginResp.Token,
+		username:    name,
+		deviceID:    deviceID,
+		client:      client,
+		selfAddr:    selfAddr,
+		peerAddrs:   make(map[string]ffi.Address),
+		peerReady:   make(map[string]bool),
+		peerDevices: make(map[string]map[uint32]struct{}),
+		httpClient:  httpClient,
+		serverURL:   server,
+	}
+
+	if err := publishBundle(state); err != nil {
+		cleanupSession(state)
+		return fmt.Errorf("upload bundle: %w", err)
+	}
+
+	sessionLoop(reader, state)
+	cleanupSession(state)
+	return nil
+}
+
+func sessionLoop(reader *bufio.Reader, state *sessionState) {
+	fmt.Println("Available commands: send <user> <device> <message>, sendall <user> <message>, refresh, logout")
+	for {
+		line := strings.TrimSpace(readLine(reader, "session> "))
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		switch strings.ToLower(fields[0]) {
+		case "send":
+			parts := strings.SplitN(line, " ", 4)
+			if len(parts) < 4 {
+				fmt.Println("Usage: send <user> <device> <message>")
+				continue
+			}
+			peer := strings.TrimSpace(parts[1])
+			deviceID, err := parseDeviceIDString(strings.TrimSpace(parts[2]))
+			if err != nil {
+				fmt.Printf("invalid device id: %v\n", err)
+				continue
+			}
+			message := strings.TrimSpace(parts[3])
+			if message == "" {
+				fmt.Println("Message must not be empty.")
+				continue
+			}
+			if err := sendMessage(state, peer, deviceID, []byte(message)); err != nil {
+				fmt.Printf("send failed: %v\n", err)
+			}
+		case "sendall":
+			parts := strings.SplitN(line, " ", 3)
+			if len(parts) < 3 {
+				fmt.Println("Usage: sendall <user> <message>")
+				continue
+			}
+			peer := strings.TrimSpace(parts[1])
+			message := strings.TrimSpace(parts[2])
+			if message == "" {
+				fmt.Println("Message must not be empty.")
+				continue
+			}
+			devices := state.peerDevices[peer]
+			if len(devices) == 0 {
+				fmt.Println("No known devices for that user. Try refresh or send with a specific device first.")
+				continue
+			}
+			for deviceID := range devices {
+				if err := sendMessage(state, peer, deviceID, []byte(message)); err != nil {
+					fmt.Printf("send to %s/%d failed: %v\n", peer, deviceID, err)
+				}
+			}
+		case "refresh":
+			if err := refreshInbox(state); err != nil {
+				fmt.Printf("refresh failed: %v\n", err)
+			}
+		case "logout":
+			fmt.Println("Logged out.")
+			return
+		default:
+			fmt.Println("Unknown command. Try: send <user> <device> <message>, sendall <user> <message>, refresh, logout")
+		}
+	}
+}
+
+func publishBundle(state *sessionState) error {
+	bundle, err := state.client.GeneratePreKeyBundle(registrationID, state.deviceID, 1, 1, 1)
+	if err != nil {
+		return err
+	}
+	defer ffi.FreePreKeyBundle(bundle)
+
+	payload, err := ffi.BundleToPayload(bundle)
+	if err != nil {
+		return err
+	}
+	url := fmt.Sprintf("%s/v1/devices/%s/%d/bundle", state.serverURL, state.username, state.deviceID)
+	return postJSON(state.httpClient, url, payload, state.token)
+}
+
+func sendMessage(state *sessionState, peer string, peerDevice uint32, plaintext []byte) error {
+	addPeerDevice(state, peer, peerDevice)
+	if err := ensurePeerReady(state, peer, peerDevice); err != nil {
+		return err
+	}
+	key := peerKey(peer, peerDevice)
+	peerAddr := state.peerAddrs[key]
+	msg, err := state.client.Encrypt(peerAddr, plaintext)
+	if err != nil {
+		return err
+	}
+	defer ffi.FreeCiphertext(msg)
+
+	req := sendRequest{
+		From:       protocolAddressJSON{Name: state.username, DeviceID: state.deviceID},
+		To:         protocolAddressJSON{Name: peer, DeviceID: peerDevice},
+		CipherType: ffi.CiphertextType(msg),
+		Payload:    ffi.CiphertextBytes(msg),
+	}
+	url := fmt.Sprintf("%s/v1/messages", state.serverURL)
+	if err := postJSON(state.httpClient, url, req, state.token); err != nil {
+		return err
+	}
+	fmt.Printf("Sent %d bytes to %s/%d.\n", len(req.Payload), peer, peerDevice)
+	return nil
+}
+
+func refreshInbox(state *sessionState) error {
+	url := fmt.Sprintf("%s/v1/messages/%s/%d", state.serverURL, state.username, state.deviceID)
+	var inbox []queuedMessage
+	if err := getJSON(state.httpClient, url, state.token, &inbox); err != nil {
+		return err
+	}
+	if len(inbox) == 0 {
+		fmt.Println("No new messages.")
+		return nil
+	}
+	for _, msg := range inbox {
+		peer := msg.From.Name
+		addPeerDevice(state, peer, msg.From.DeviceID)
+		if err := ensurePeerReady(state, peer, msg.From.DeviceID); err != nil {
+			fmt.Printf("cannot decrypt message from %s: %v\n", peer, err)
+			continue
+		}
+		key := peerKey(peer, msg.From.DeviceID)
+		peerAddr := state.peerAddrs[key]
+		plaintext, err := decryptMessage(state.client, peerAddr, msg)
+		if err != nil {
+			fmt.Printf("decrypt failed for %s: %v\n", peer, err)
+			continue
+		}
+		fmt.Printf("[%s/%d] %s\n", peer, msg.From.DeviceID, plaintext)
+	}
+	return nil
+}
+
+func ensurePeerReady(state *sessionState, peer string, peerDevice uint32) error {
+	addPeerDevice(state, peer, peerDevice)
+	key := peerKey(peer, peerDevice)
+	if ready := state.peerReady[key]; ready {
+		return nil
+	}
+	addr, ok := state.peerAddrs[key]
+	if !ok {
+		var err error
+		addr, err = ffi.NewAddress(peer, peerDevice)
+		if err != nil {
+			return err
+		}
+		state.peerAddrs[key] = addr
+	}
+
+	bundle, err := fetchBundle(state.httpClient, state.serverURL, peer, peerDevice, state.token)
+	if err != nil {
+		return err
+	}
+	remoteBundle, err := ffi.BundleFromPayload(bundle)
+	if err != nil {
+		return err
+	}
+	defer ffi.FreePreKeyBundle(remoteBundle)
+
+	if err := state.client.ProcessPreKeyBundle(state.peerAddrs[key], remoteBundle); err != nil {
+		return err
+	}
+	state.peerReady[key] = true
+	return nil
+}
+
+func decryptMessage(client *ffi.Client, peerAddr ffi.Address, msg queuedMessage) (string, error) {
+	switch msg.CipherType {
+	case ffi.CiphertextTypePreKey:
+		pk, err := ffi.PreKeySignalMessageFromBytes(msg.Payload)
+		if err != nil {
+			return "", err
+		}
+		defer ffi.FreePreKeySignalMessage(pk)
+		plaintext, err := client.DecryptPreKey(peerAddr, pk)
+		if err != nil {
+			return "", err
+		}
+		return string(plaintext), nil
+	case ffi.CiphertextTypeWhisper:
+		sig, err := ffi.SignalMessageFromBytes(msg.Payload)
+		if err != nil {
+			return "", err
+		}
+		defer ffi.FreeSignalMessage(sig)
+		plaintext, err := client.DecryptSignal(peerAddr, sig)
+		if err != nil {
+			return "", err
+		}
+		return string(plaintext), nil
+	default:
+		return "", fmt.Errorf("unknown ciphertext type %d", msg.CipherType)
+	}
+}
+
+func cleanupSession(state *sessionState) {
+	for _, addr := range state.peerAddrs {
+		ffi.FreeAddress(addr)
+	}
+	ffi.FreeAddress(state.selfAddr)
+	state.client.Close()
+}
+
+func readLine(reader *bufio.Reader, prompt string) string {
+	fmt.Print(prompt)
+	line, _ := reader.ReadString('\n')
+	return strings.TrimRight(line, "\r\n")
+}
+
+func promptDeviceID(reader *bufio.Reader) (uint32, error) {
+	for {
+		input := strings.TrimSpace(readLine(reader, "Device ID (1-127): "))
+		value, err := parseDeviceIDString(input)
+		if err != nil {
+			fmt.Printf("Invalid device id: %v\n", err)
+			continue
+		}
+		return value, nil
+	}
+}
+
+func parseDeviceIDString(value string) (uint32, error) {
+	parsed, err := strconv.ParseUint(value, 10, 32)
+	if err != nil {
+		return 0, err
+	}
+	if parsed == 0 || parsed > 127 {
+		return 0, fmt.Errorf("out of range")
+	}
+	return uint32(parsed), nil
+}
+
+func addPeerDevice(state *sessionState, peer string, deviceID uint32) {
+	devices, ok := state.peerDevices[peer]
+	if !ok {
+		devices = make(map[uint32]struct{})
+		state.peerDevices[peer] = devices
+	}
+	devices[deviceID] = struct{}{}
+}
+
+func peerKey(peer string, deviceID uint32) string {
+	return fmt.Sprintf("%s:%d", peer, deviceID)
+}
+
+func fetchBundle(httpClient *http.Client, serverURL, name string, deviceID uint32, token string) (*transport.BundlePayload, error) {
+	url := fmt.Sprintf("%s/v1/devices/%s/%d/bundle", serverURL, name, deviceID)
+	var payload transport.BundlePayload
+	if err := getJSON(httpClient, url, token, &payload); err != nil {
+		return nil, err
+	}
+	return &payload, nil
+}
+
+func postJSON(client *http.Client, url string, body any, token string) error {
+	return postAndDecode(client, url, body, token, nil)
+}
+
+func postAndDecode(client *http.Client, url string, body any, token string, out any) error {
+	data, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.Header.Set("X-Session-Token", token)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		b, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("POST %s status %d: %s", url, resp.StatusCode, bytes.TrimSpace(b))
+	}
+	if out != nil {
+		return json.NewDecoder(resp.Body).Decode(out)
+	}
+	return nil
+}
+
+func getJSON(client *http.Client, url string, token string, out any) error {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	if token != "" {
+		req.Header.Set("X-Session-Token", token)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		b, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("GET %s status %d: %s", url, resp.StatusCode, bytes.TrimSpace(b))
+	}
+	if out != nil {
+		return json.NewDecoder(resp.Body).Decode(out)
+	}
+	return nil
+}

--- a/examples/go/cmd/server/README.md
+++ b/examples/go/cmd/server/README.md
@@ -1,0 +1,64 @@
+# Signal Demo HTTP Server
+
+This example exposes a minimal HTTP API that demonstrates how the Go bindings interact with the in-memory Signal helper types inside the repo. The server keeps a lightweight database in memory, so it is best used for local/testing purposes.
+
+## What It Does
+
+- Handles user registration and login with short-lived session tokens.
+- Stores pre-key bundles per `{user, device}` so peers can establish secure sessions.
+- Queues encrypted messages for offline delivery and lets clients drain their inbox.
+- Logs every request (including request bodies) to help troubleshoot API calls.
+
+The storage layer lives entirely in `main.go` and is intentionally simple: a
+`memoryStore` struct holds users, bundles, queues, and sessions guarded by a RW
+mutex.
+
+## Prerequisites
+
+1. Build the Rust `signal-c-binding` shim in release mode (produces the static
+   archive consumed by the Go example):
+   ```bash
+   cargo build -p signal-c-binding --release
+   ```
+2. Run Go commands with an explicit build cache inside the repository to avoid
+   `$HOME` permissions issues when running in sandboxes:
+   ```bash
+   export GOCACHE=$(pwd)/examples/go/.gocache
+   ```
+
+## Running the Server
+
+```bash
+GOCACHE=$(pwd)/examples/go/.gocache go run ./examples/go/cmd/server --listen :8080
+```
+
+The `--listen` flag is optional; it defaults to `:8080`. On startup the server
+prints each HTTP request twice: once with the method/path/body and once after
+the handler finishes with latency information.
+
+## API Overview
+
+| Method | Path                           | Purpose                                    |
+| ------ | ------------------------------ | ------------------------------------------ |
+| POST   | `/v1/register`                 | Create a new `{name, password}` account.   |
+| POST   | `/v1/login`                    | Issue an `X-Session-Token` for a device.   |
+| POST   | `/v1/devices/{name}/{id}/bundle` | Upload the caller's pre-key bundle.        |
+| GET    | `/v1/devices/{name}/{id}/bundle` | Fetch a bundle to start a session.         |
+| POST   | `/v1/messages`                 | Queue an encrypted message for a peer.     |
+| GET    | `/v1/messages/{name}/{id}`     | Drain pending messages for a device.       |
+
+Protected endpoints require the `X-Session-Token` header returned by `/v1/login`.
+Handlers respond with JSON payloads and standard HTTP status codes.
+
+## Typical Flow
+
+1. Client registers a username/password via `/v1/register`.
+2. Client logs in on a device, receiving a session token and publishing its
+   bundle through `/v1/devices/.../bundle`.
+3. When sending, the client fetches the peer's bundle (if necessary), encrypts
+   the message locally, and POSTs the ciphertext to `/v1/messages`.
+4. The recipient periodically calls `/v1/messages/{name}/{id}` to retrieve and
+   decrypt queued messages.
+
+Refer to `examples/go/cmd/client/README.md` (or run the CLI) for a convenient
+way to drive these endpoints interactively.

--- a/examples/go/cmd/server/main.go
+++ b/examples/go/cmd/server/main.go
@@ -1,0 +1,477 @@
+package main
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	transport "signalexample/transport"
+)
+
+type protocolAddress struct {
+	Name     string `json:"name"`
+	DeviceID uint32 `json:"device_id"`
+}
+
+type queuedMessage struct {
+	From       protocolAddress `json:"from"`
+	CipherType uint8           `json:"cipher_type"`
+	Payload    []byte          `json:"payload"`
+	Timestamp  int64           `json:"timestamp"`
+}
+
+type sendRequest struct {
+	From       protocolAddress `json:"from"`
+	To         protocolAddress `json:"to"`
+	CipherType uint8           `json:"cipher_type"`
+	Payload    []byte          `json:"payload"`
+}
+
+type registerRequest struct {
+	Name     string `json:"name"`
+	Password string `json:"password"`
+}
+
+type loginRequest struct {
+	Name     string `json:"name"`
+	Password string `json:"password"`
+	DeviceID uint32 `json:"device_id"`
+}
+
+type loginResponse struct {
+	Token string `json:"token"`
+}
+
+type user struct {
+	Password string
+	Bundles  map[uint32]*transport.BundlePayload
+	Queues   map[uint32][]queuedMessage
+}
+
+type session struct {
+	Name     string
+	DeviceID uint32
+	Expires  time.Time
+}
+
+type memoryStore struct {
+	mu       sync.RWMutex
+	users    map[string]*user
+	sessions map[string]session
+}
+
+func newMemoryStore() *memoryStore {
+	return &memoryStore{
+		users:    make(map[string]*user),
+		sessions: make(map[string]session),
+	}
+}
+
+func (s *memoryStore) createUser(name, password string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.users[name]; exists {
+		return fmt.Errorf("user %s already exists", name)
+	}
+	s.users[name] = &user{
+		Password: password,
+		Bundles:  make(map[uint32]*transport.BundlePayload),
+		Queues:   make(map[uint32][]queuedMessage),
+	}
+	return nil
+}
+
+func (s *memoryStore) verifyUser(name, password string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	u, ok := s.users[name]
+	if !ok {
+		return false
+	}
+	return u.Password == password
+}
+
+func (s *memoryStore) putBundle(name string, deviceID uint32, payload *transport.BundlePayload) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	u, ok := s.users[name]
+	if !ok {
+		return fmt.Errorf("unknown user %s", name)
+	}
+	copy := *payload
+	u.Bundles[deviceID] = &copy
+	return nil
+}
+
+func (s *memoryStore) getBundle(name string, deviceID uint32) (*transport.BundlePayload, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	u, ok := s.users[name]
+	if !ok {
+		return nil, false
+	}
+	payload, ok := u.Bundles[deviceID]
+	if !ok {
+		return nil, false
+	}
+	copy := *payload
+	return &copy, true
+}
+
+func (s *memoryStore) enqueue(name string, deviceID uint32, message queuedMessage) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	u, ok := s.users[name]
+	if !ok {
+		return fmt.Errorf("unknown user %s", name)
+	}
+	// Copy payload to avoid sharing slices across goroutines.
+	cloned := message
+	cloned.Payload = append([]byte(nil), message.Payload...)
+	u.Queues[deviceID] = append(u.Queues[deviceID], cloned)
+	return nil
+}
+
+func (s *memoryStore) drain(name string, deviceID uint32) ([]queuedMessage, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	u, ok := s.users[name]
+	if !ok {
+		return nil, fmt.Errorf("unknown user %s", name)
+	}
+	messages := u.Queues[deviceID]
+	delete(u.Queues, deviceID)
+	return messages, nil
+}
+
+func (s *memoryStore) newSession(name string, deviceID uint32, ttl time.Duration) (string, session, error) {
+	token, err := generateToken()
+	if err != nil {
+		return "", session{}, err
+	}
+	sess := session{
+		Name:     name,
+		DeviceID: deviceID,
+		Expires:  time.Now().Add(ttl),
+	}
+	s.mu.Lock()
+	s.sessions[token] = sess
+	s.mu.Unlock()
+	return token, sess, nil
+}
+
+func (s *memoryStore) getSession(token string) (session, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	sess, ok := s.sessions[token]
+	if !ok {
+		return session{}, false
+	}
+	if time.Now().After(sess.Expires) {
+		return session{}, false
+	}
+	return sess, true
+}
+
+func generateToken() (string, error) {
+	var buf [16]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buf[:]), nil
+}
+
+func main() {
+	listen := flag.String("listen", ":8080", "address to listen on")
+	flag.Parse()
+
+	store := newMemoryStore()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/register", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			httpError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		handleRegister(store, w, r)
+	})
+	mux.HandleFunc("/v1/login", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			httpError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		handleLogin(store, w, r)
+	})
+	mux.HandleFunc("/v1/devices/", func(w http.ResponseWriter, r *http.Request) {
+		sess, ok := requireSession(store, w, r)
+		if !ok {
+			return
+		}
+		switch r.Method {
+		case http.MethodPost:
+			handleSetBundle(store, sess, w, r)
+		case http.MethodGet:
+			handleGetBundle(store, w, r)
+		default:
+			httpError(w, http.StatusMethodNotAllowed, "method not allowed")
+		}
+	})
+	mux.HandleFunc("/v1/messages", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			httpError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		sess, ok := requireSession(store, w, r)
+		if !ok {
+			return
+		}
+		handleEnqueueMessage(store, sess, w, r)
+	})
+	mux.HandleFunc("/v1/messages/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			httpError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		sess, ok := requireSession(store, w, r)
+		if !ok {
+			return
+		}
+		handleDrainMessages(store, sess, w, r)
+	})
+
+	server := &http.Server{
+		Addr:    *listen,
+		Handler: requestLogger(mux),
+	}
+
+	log.Printf("Signal demo server listening on %s", *listen)
+	if err := server.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
+		log.Fatalf("server stopped: %v", err)
+	}
+}
+
+func handleRegister(store *memoryStore, w http.ResponseWriter, r *http.Request) {
+	var req registerRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		httpError(w, http.StatusBadRequest, fmt.Sprintf("invalid JSON: %v", err))
+		return
+	}
+	if req.Name == "" || req.Password == "" {
+		httpError(w, http.StatusBadRequest, "name and password are required")
+		return
+	}
+	if err := store.createUser(req.Name, req.Password); err != nil {
+		httpError(w, http.StatusConflict, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusCreated, map[string]string{"status": "registered"})
+}
+
+func handleLogin(store *memoryStore, w http.ResponseWriter, r *http.Request) {
+	var req loginRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		httpError(w, http.StatusBadRequest, fmt.Sprintf("invalid JSON: %v", err))
+		return
+	}
+	if !store.verifyUser(req.Name, req.Password) {
+		httpError(w, http.StatusUnauthorized, "invalid credentials")
+		return
+	}
+	token, sess, err := store.newSession(req.Name, req.DeviceID, 12*time.Hour)
+	if err != nil {
+		httpError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	log.Printf("login user=%s device=%d token=%s expires=%s", sess.Name, sess.DeviceID, token, sess.Expires.Format(time.RFC3339))
+	writeJSON(w, http.StatusOK, loginResponse{Token: token})
+}
+
+func handleSetBundle(store *memoryStore, sess session, w http.ResponseWriter, r *http.Request) {
+	name, deviceID, err := parseDevicePath(r.URL.Path)
+	if err != nil {
+		httpError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if name != sess.Name || deviceID != sess.DeviceID {
+		httpError(w, http.StatusForbidden, "cannot upload bundle for another device")
+		return
+	}
+
+	var payload transport.BundlePayload
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		httpError(w, http.StatusBadRequest, fmt.Sprintf("invalid JSON: %v", err))
+		return
+	}
+	if payload.RegistrationID == 0 {
+		httpError(w, http.StatusBadRequest, "registration_id is required")
+		return
+	}
+	payload.DeviceID = deviceID
+
+	if err := store.putBundle(name, deviceID, &payload); err != nil {
+		httpError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "stored"})
+}
+
+func handleGetBundle(store *memoryStore, w http.ResponseWriter, r *http.Request) {
+	name, deviceID, err := parseDevicePath(r.URL.Path)
+	if err != nil {
+		httpError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	payload, ok := store.getBundle(name, deviceID)
+	if !ok {
+		httpError(w, http.StatusNotFound, "bundle not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, payload)
+}
+
+func handleEnqueueMessage(store *memoryStore, sess session, w http.ResponseWriter, r *http.Request) {
+	var req sendRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		httpError(w, http.StatusBadRequest, fmt.Sprintf("invalid JSON: %v", err))
+		return
+	}
+	fmt.Print(req)
+	if req.Payload == nil {
+		httpError(w, http.StatusBadRequest, "payload is required")
+		return
+	}
+	if req.From.Name != sess.Name || req.From.DeviceID != sess.DeviceID {
+		httpError(w, http.StatusForbidden, "session does not match sender")
+		return
+	}
+	message := queuedMessage{
+		From:       req.From,
+		CipherType: req.CipherType,
+		Payload:    req.Payload,
+		Timestamp:  time.Now().UnixMilli(),
+	}
+	if err := store.enqueue(req.To.Name, req.To.DeviceID, message); err != nil {
+		httpError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "queued"})
+}
+
+func handleDrainMessages(store *memoryStore, sess session, w http.ResponseWriter, r *http.Request) {
+	name, deviceID, err := parseMessagesPath(r.URL.Path)
+	if err != nil {
+		httpError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if name != sess.Name || deviceID != sess.DeviceID {
+		httpError(w, http.StatusForbidden, "session does not match inbox")
+		return
+	}
+	messages, err := store.drain(name, deviceID)
+	if err != nil {
+		httpError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, messages)
+}
+
+func requireSession(store *memoryStore, w http.ResponseWriter, r *http.Request) (session, bool) {
+	token := r.Header.Get("X-Session-Token")
+	if token == "" {
+		httpError(w, http.StatusUnauthorized, "missing session token")
+		return session{}, false
+	}
+	sess, ok := store.getSession(token)
+	if !ok {
+		httpError(w, http.StatusUnauthorized, "invalid session token")
+		return session{}, false
+	}
+	return sess, true
+}
+
+func parseDevicePath(path string) (string, uint32, error) {
+	suffix := strings.TrimPrefix(path, "/v1/devices/")
+	parts := strings.Split(suffix, "/")
+	if len(parts) != 3 || parts[2] != "bundle" {
+		return "", 0, fmt.Errorf("expected /v1/devices/{name}/{device}/bundle, got %s", path)
+	}
+	deviceID, err := parseDeviceID(parts[1])
+	if err != nil {
+		return "", 0, err
+	}
+	return parts[0], deviceID, nil
+}
+
+func parseMessagesPath(path string) (string, uint32, error) {
+	suffix := strings.TrimPrefix(path, "/v1/messages/")
+	parts := strings.Split(suffix, "/")
+	if len(parts) != 2 {
+		return "", 0, fmt.Errorf("expected /v1/messages/{name}/{device}, got %s", path)
+	}
+	deviceID, err := parseDeviceID(parts[1])
+	if err != nil {
+		return "", 0, err
+	}
+	return parts[0], deviceID, nil
+}
+
+func parseDeviceID(raw string) (uint32, error) {
+	if raw == "" {
+		return 0, errors.New("device id is required")
+	}
+	value, err := strconv.ParseUint(raw, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid device id: %w", err)
+	}
+	return uint32(value), nil
+}
+
+func requestLogger(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+
+		var bodyCopy []byte
+		if r.Body != nil {
+			var err error
+			bodyCopy, err = io.ReadAll(r.Body)
+			if err != nil {
+				log.Printf("failed to read request body: %v", err)
+			}
+			if err := r.Body.Close(); err != nil {
+				log.Printf("failed to close request body: %v", err)
+			}
+			r.Body = io.NopCloser(bytes.NewReader(bodyCopy))
+		}
+
+		if len(bodyCopy) > 0 {
+			// log.Printf("%s %s body=%s", r.Method, r.URL.Path, string(bodyCopy))
+		} else {
+			log.Printf("%s %s body=<empty>", r.Method, r.URL.Path)
+		}
+		next.ServeHTTP(w, r)
+		duration := time.Since(start).Truncate(time.Millisecond)
+		log.Printf("%s %s %s", r.Method, r.URL.Path, duration)
+	})
+}
+
+func httpError(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, map[string]string{"error": msg})
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(body); err != nil {
+		log.Printf("write JSON failed: %v", err)
+	}
+}

--- a/examples/go/ffi/bundle.go
+++ b/examples/go/ffi/bundle.go
@@ -1,0 +1,176 @@
+package ffi
+
+/*
+#include "signal_c_binding.h"
+*/
+import "C"
+
+import (
+	"errors"
+	"unsafe"
+
+	"signalexample/transport"
+)
+
+func BundleToPayload(bundle *C.SignalGoPreKeyBundle) (*transport.BundlePayload, error) {
+	if bundle == nil {
+		return nil, errors.New("bundle pointer is nil")
+	}
+
+	var payload transport.BundlePayload
+
+	var regID C.uint32_t
+	if err := ffiCode(C.signalgo_prekey_bundle_get_registration_id(bundle, &regID), "get_registration_id"); err != nil {
+		return nil, err
+	}
+	payload.RegistrationID = uint32(regID)
+
+	var deviceID C.uint32_t
+	if err := ffiCode(C.signalgo_prekey_bundle_get_device_id(bundle, &deviceID), "get_device_id"); err != nil {
+		return nil, err
+	}
+	payload.DeviceID = uint32(deviceID)
+
+	var hasPreKey C.bool
+	var preKeyID C.uint32_t
+	if err := ffiCode(C.signalgo_prekey_bundle_get_prekey_id(bundle, &hasPreKey, &preKeyID), "get_prekey_id"); err != nil {
+		return nil, err
+	}
+
+	var preKeyPtr *C.uint8_t
+	var preKeyLen C.size_t
+	if err := ffiCode(C.signalgo_prekey_bundle_get_prekey_public(bundle, &preKeyPtr, &preKeyLen), "get_prekey_public"); err != nil {
+		return nil, err
+	}
+	if bool(hasPreKey) {
+		payload.PreKey = &transport.PreKeyEnvelope{
+			ID:     uint32(preKeyID),
+			Public: copyAndFree(preKeyPtr, preKeyLen),
+		}
+	} else {
+		if preKeyPtr != nil {
+			C.signalgo_buffer_free(preKeyPtr, preKeyLen)
+		}
+	}
+
+	var signedID C.uint32_t
+	if err := ffiCode(C.signalgo_prekey_bundle_get_signed_prekey_id(bundle, &signedID), "get_signed_prekey_id"); err != nil {
+		return nil, err
+	}
+
+	var signedPtr *C.uint8_t
+	var signedLen C.size_t
+	if err := ffiCode(C.signalgo_prekey_bundle_get_signed_prekey_public(bundle, &signedPtr, &signedLen), "get_signed_prekey_public"); err != nil {
+		return nil, err
+	}
+	signedPublic := copyAndFree(signedPtr, signedLen)
+
+	var signedSigPtr *C.uint8_t
+	var signedSigLen C.size_t
+	if err := ffiCode(C.signalgo_prekey_bundle_get_signed_prekey_signature(bundle, &signedSigPtr, &signedSigLen), "get_signed_prekey_signature"); err != nil {
+		return nil, err
+	}
+	signedSignature := copyAndFree(signedSigPtr, signedSigLen)
+
+	payload.SignedPreKey = transport.SignedPreKeyEnvelope{
+		ID:        uint32(signedID),
+		Public:    signedPublic,
+		Signature: signedSignature,
+	}
+
+	var identityPtr *C.uint8_t
+	var identityLen C.size_t
+	if err := ffiCode(C.signalgo_prekey_bundle_get_identity_key(bundle, &identityPtr, &identityLen), "get_identity_key"); err != nil {
+		return nil, err
+	}
+	payload.IdentityKey = copyAndFree(identityPtr, identityLen)
+
+	var kyberID C.uint32_t
+	if err := ffiCode(C.signalgo_prekey_bundle_get_kyber_prekey_id(bundle, &kyberID), "get_kyber_prekey_id"); err != nil {
+		return nil, err
+	}
+
+	var kyberPtr *C.uint8_t
+	var kyberLen C.size_t
+	if err := ffiCode(C.signalgo_prekey_bundle_get_kyber_prekey_public(bundle, &kyberPtr, &kyberLen), "get_kyber_prekey_public"); err != nil {
+		return nil, err
+	}
+	kyberPublic := copyAndFree(kyberPtr, kyberLen)
+
+	var kyberSigPtr *C.uint8_t
+	var kyberSigLen C.size_t
+	if err := ffiCode(C.signalgo_prekey_bundle_get_kyber_prekey_signature(bundle, &kyberSigPtr, &kyberSigLen), "get_kyber_prekey_signature"); err != nil {
+		return nil, err
+	}
+	kyberSignature := copyAndFree(kyberSigPtr, kyberSigLen)
+
+	payload.KyberPreKey = transport.KyberPreKeyEnvelope{
+		ID:        uint32(kyberID),
+		Public:    kyberPublic,
+		Signature: kyberSignature,
+	}
+
+	return &payload, nil
+}
+
+func BundleFromPayload(payload *transport.BundlePayload) (*C.SignalGoPreKeyBundle, error) {
+	if payload == nil {
+		return nil, errors.New("payload is nil")
+	}
+	if len(payload.IdentityKey) == 0 {
+		return nil, errors.New("identity key is required")
+	}
+	if len(payload.SignedPreKey.Public) == 0 || len(payload.SignedPreKey.Signature) == 0 {
+		return nil, errors.New("signed pre-key is incomplete")
+	}
+	if len(payload.KyberPreKey.Public) == 0 || len(payload.KyberPreKey.Signature) == 0 {
+		return nil, errors.New("kyber pre-key is incomplete")
+	}
+
+	hasPreKey := C.bool(false)
+	var preKeyID C.uint32_t
+	var preKeyPtr *C.uint8_t
+	var preKeyLen C.size_t
+	if payload.PreKey != nil {
+		if len(payload.PreKey.Public) == 0 {
+			return nil, errors.New("pre-key public is empty")
+		}
+		hasPreKey = C.bool(true)
+		preKeyID = C.uint32_t(payload.PreKey.ID)
+		preKeyLen = C.size_t(len(payload.PreKey.Public))
+		preKeyPtr = (*C.uint8_t)(unsafe.Pointer(&payload.PreKey.Public[0]))
+	}
+
+	signedPublic := (*C.uint8_t)(unsafe.Pointer(&payload.SignedPreKey.Public[0]))
+	signedSignature := (*C.uint8_t)(unsafe.Pointer(&payload.SignedPreKey.Signature[0]))
+	identityPtr := (*C.uint8_t)(unsafe.Pointer(&payload.IdentityKey[0]))
+	kyberPublic := (*C.uint8_t)(unsafe.Pointer(&payload.KyberPreKey.Public[0]))
+	kyberSignature := (*C.uint8_t)(unsafe.Pointer(&payload.KyberPreKey.Signature[0]))
+
+	var out *C.SignalGoPreKeyBundle
+	rc := C.signalgo_prekey_bundle_from_parts(
+		C.uint32_t(payload.RegistrationID),
+		C.uint32_t(payload.DeviceID),
+		hasPreKey,
+		preKeyID,
+		preKeyPtr,
+		preKeyLen,
+		C.uint32_t(payload.SignedPreKey.ID),
+		signedPublic,
+		C.size_t(len(payload.SignedPreKey.Public)),
+		signedSignature,
+		C.size_t(len(payload.SignedPreKey.Signature)),
+		identityPtr,
+		C.size_t(len(payload.IdentityKey)),
+		C.uint32_t(payload.KyberPreKey.ID),
+		kyberPublic,
+		C.size_t(len(payload.KyberPreKey.Public)),
+		kyberSignature,
+		C.size_t(len(payload.KyberPreKey.Signature)),
+		&out,
+	)
+	if err := ffiCode(rc, "prekey_bundle_from_parts"); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/examples/go/ffi/client.go
+++ b/examples/go/ffi/client.go
@@ -1,0 +1,230 @@
+package ffi
+
+/*
+#cgo CFLAGS: -I${SRCDIR}/../../../signal-c-binding/include
+#cgo LDFLAGS: -L${SRCDIR}/../../../target/release -lsignal_c_binding -ldl -lpthread -lm
+#include <stdlib.h>
+#include "signal_c_binding.h"
+*/
+import "C"
+
+import (
+	"fmt"
+	"runtime"
+	"time"
+	"unsafe"
+)
+
+const (
+	CiphertextTypeUnknown     = 0
+	CiphertextTypeKeyExchange = 1
+	CiphertextTypeWhisper     = 2
+	CiphertextTypePreKey      = 3
+)
+
+func ffiCode(rc C.int32_t, action string) error {
+	if rc != 0 {
+		return fmt.Errorf("%s: signal ffi returned %d", action, int(rc))
+	}
+	return nil
+}
+
+type Client struct {
+	Name  string
+	store *C.SignalGoProtocolStore
+}
+
+type Address = *C.SignalGoProtocolAddress
+type CiphertextMessage = *C.SignalGoCiphertextMessage
+type SignalMessage = *C.SignalGoSignalMessage
+type PreKeySignalMessage = *C.SignalGoPreKeySignalMessage
+type PreKeyBundle = *C.SignalGoPreKeyBundle
+
+func NewClient(name string, registrationID, deviceID uint32) (*Client, error) {
+	identity := C.signalgo_identity_keypair_generate()
+	if identity == nil {
+		return nil, fmt.Errorf("%s: failed to generate identity key pair", name)
+	}
+	defer C.signalgo_identity_keypair_free(identity)
+
+	store := C.signalgo_protocol_store_new(identity, C.uint32_t(registrationID))
+	if store == nil {
+		return nil, fmt.Errorf("%s: failed to create protocol store", name)
+	}
+
+	c := &Client{Name: name, store: store}
+	runtime.SetFinalizer(c, (*Client).Close)
+	return c, nil
+}
+
+func (c *Client) Close() {
+	if c.store != nil {
+		C.signalgo_protocol_store_free(c.store)
+		c.store = nil
+	}
+}
+
+func (c *Client) GeneratePreKeyBundle(registrationID, deviceID, preKeyID, signedPreKeyID, kyberPreKeyID uint32) (*C.SignalGoPreKeyBundle, error) {
+	var bundle *C.SignalGoPreKeyBundle
+	rc := C.signalgo_store_generate_prekey_bundle(
+		c.store,
+		C.uint32_t(registrationID),
+		C.uint32_t(deviceID),
+		C.uint32_t(preKeyID),
+		C.uint32_t(signedPreKeyID),
+		C.uint32_t(kyberPreKeyID),
+		(**C.SignalGoPreKeyBundle)(unsafe.Pointer(&bundle)),
+	)
+	if rc != 0 || bundle == nil {
+		return nil, fmt.Errorf("%s: failed to generate pre-key bundle (code %d)", c.Name, int(rc))
+	}
+	return bundle, nil
+}
+
+func (c *Client) ProcessPreKeyBundle(remote *C.SignalGoProtocolAddress, bundle *C.SignalGoPreKeyBundle) error {
+	now := time.Now().UnixMilli()
+	rc := C.signalgo_store_process_prekey_bundle(
+		c.store,
+		remote,
+		bundle,
+		C.uint64_t(now),
+		C.bool(true),
+	)
+	if rc != 0 {
+		return fmt.Errorf("%s: process_prekey_bundle failed with code %d", c.Name, int(rc))
+	}
+	return nil
+}
+
+func (c *Client) Encrypt(remote *C.SignalGoProtocolAddress, plaintext []byte) (*C.SignalGoCiphertextMessage, error) {
+	if len(plaintext) == 0 {
+		return nil, fmt.Errorf("%s: plaintext is empty", c.Name)
+	}
+	var message *C.SignalGoCiphertextMessage
+	rc := C.signalgo_store_encrypt_message(
+		c.store,
+		remote,
+		(*C.uint8_t)(unsafe.Pointer(&plaintext[0])),
+		C.size_t(len(plaintext)),
+		C.uint64_t(time.Now().UnixMilli()),
+		(**C.SignalGoCiphertextMessage)(unsafe.Pointer(&message)),
+	)
+	if rc != 0 || message == nil {
+		return nil, fmt.Errorf("%s: encrypt failed with code %d", c.Name, int(rc))
+	}
+	return message, nil
+}
+
+func (c *Client) DecryptSignal(remote *C.SignalGoProtocolAddress, msg *C.SignalGoSignalMessage) ([]byte, error) {
+	var outPtr *C.uint8_t
+	var outLen C.size_t
+	rc := C.signalgo_store_decrypt_signal_message(
+		c.store,
+		remote,
+		msg,
+		(**C.uint8_t)(unsafe.Pointer(&outPtr)),
+		(*C.size_t)(unsafe.Pointer(&outLen)),
+	)
+	if rc != 0 {
+		return nil, fmt.Errorf("%s: decrypt_signal failed with code %d", c.Name, int(rc))
+	}
+	return copyAndFree(outPtr, outLen), nil
+}
+
+func (c *Client) DecryptPreKey(remote *C.SignalGoProtocolAddress, msg *C.SignalGoPreKeySignalMessage) ([]byte, error) {
+	var outPtr *C.uint8_t
+	var outLen C.size_t
+	rc := C.signalgo_store_decrypt_prekey_message(
+		c.store,
+		remote,
+		msg,
+		C.bool(true),
+		(**C.uint8_t)(unsafe.Pointer(&outPtr)),
+		(*C.size_t)(unsafe.Pointer(&outLen)),
+	)
+	if rc != 0 {
+		return nil, fmt.Errorf("%s: decrypt_prekey failed with code %d", c.Name, int(rc))
+	}
+	return copyAndFree(outPtr, outLen), nil
+}
+
+func CiphertextType(msg *C.SignalGoCiphertextMessage) uint8 {
+	return uint8(C.signalgo_ciphertext_message_get_type(msg))
+}
+
+func CiphertextBytes(msg *C.SignalGoCiphertextMessage) []byte {
+	var outLen C.size_t
+	data := C.signalgo_ciphertext_message_serialize(msg, &outLen)
+	return copyAndFree(data, outLen)
+}
+
+func SignalMessageFromBytes(payload []byte) (*C.SignalGoSignalMessage, error) {
+	if len(payload) == 0 {
+		return nil, fmt.Errorf("signal message payload empty")
+	}
+	msg := C.signalgo_signal_message_from_bytes((*C.uint8_t)(unsafe.Pointer(&payload[0])), C.size_t(len(payload)))
+	if msg == nil {
+		return nil, fmt.Errorf("failed to parse signal message")
+	}
+	return msg, nil
+}
+
+func PreKeySignalMessageFromBytes(payload []byte) (*C.SignalGoPreKeySignalMessage, error) {
+	if len(payload) == 0 {
+		return nil, fmt.Errorf("pre-key message payload empty")
+	}
+	msg := C.signalgo_prekey_signal_message_from_bytes((*C.uint8_t)(unsafe.Pointer(&payload[0])), C.size_t(len(payload)))
+	if msg == nil {
+		return nil, fmt.Errorf("failed to parse pre-key signal message")
+	}
+	return msg, nil
+}
+
+func FreeCiphertext(msg *C.SignalGoCiphertextMessage) {
+	if msg != nil {
+		C.signalgo_ciphertext_message_free(msg)
+	}
+}
+
+func FreeSignalMessage(msg *C.SignalGoSignalMessage) {
+	if msg != nil {
+		C.signalgo_signal_message_free(msg)
+	}
+}
+
+func FreePreKeySignalMessage(msg *C.SignalGoPreKeySignalMessage) {
+	if msg != nil {
+		C.signalgo_prekey_signal_message_free(msg)
+	}
+}
+
+func FreePreKeyBundle(bundle *C.SignalGoPreKeyBundle) {
+	if bundle != nil {
+		C.signalgo_prekey_bundle_free(bundle)
+	}
+}
+
+func NewAddress(name string, deviceID uint32) (*C.SignalGoProtocolAddress, error) {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	addr := C.signalgo_protocol_address_new(cName, C.uint32_t(deviceID))
+	if addr == nil {
+		return nil, fmt.Errorf("failed to create protocol address")
+	}
+	return addr, nil
+}
+
+func FreeAddress(addr *C.SignalGoProtocolAddress) {
+	if addr != nil {
+		C.signalgo_protocol_address_free(addr)
+	}
+}
+
+func copyAndFree(ptr *C.uint8_t, length C.size_t) []byte {
+	if ptr == nil || length == 0 {
+		return nil
+	}
+	goBytes := C.GoBytes(unsafe.Pointer(ptr), C.int(length))
+	C.signalgo_buffer_free(ptr, length)
+	return goBytes
+}

--- a/examples/go/go.mod
+++ b/examples/go/go.mod
@@ -1,0 +1,4 @@
+module signalexample
+
+go 1.22
+

--- a/examples/go/main.go
+++ b/examples/go/main.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"signalexample/ffi"
+)
+
+func main() {
+	alice, err := ffi.NewClient("alice", 2024, 1)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer alice.Close()
+
+	bob, err := ffi.NewClient("bob", 2024, 1)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer bob.Close()
+
+	charlie, err := ffi.NewClient("charlie", 2024, 1)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer charlie.Close()
+
+	aliceAddr, err := ffi.NewAddress("alice", 1)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer ffi.FreeAddress(aliceAddr)
+
+	bobAddr, err := ffi.NewAddress("bob", 1)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer ffi.FreeAddress(bobAddr)
+
+	charlieAddr, err := ffi.NewAddress("charlie", 1)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer ffi.FreeAddress(charlieAddr)
+
+	bobBundle, err := bob.GeneratePreKeyBundle(2024, 1, 1, 1, 1)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer ffi.FreePreKeyBundle(bobBundle)
+
+	charlieBundle, err := charlie.GeneratePreKeyBundle(2024, 1, 1, 1, 1)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer ffi.FreePreKeyBundle(charlieBundle)
+
+	if err := alice.ProcessPreKeyBundle(bobAddr, charlieBundle); err != nil {
+		log.Fatal(err)
+	}
+
+	plaintext := []byte("Hello from Naveen via Signal Protocol!")
+	ciphertext, err := alice.Encrypt(bobAddr, plaintext)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer ffi.FreeCiphertext(ciphertext)
+
+	ctype := ffi.CiphertextType(ciphertext)
+	payload := ffi.CiphertextBytes(ciphertext)
+	fmt.Printf("Ciphertext type=%d size=%d\n", ctype, len(payload))
+
+	if len(payload) == 0 {
+		log.Fatal("empty ciphertext payload")
+	}
+
+	var decrypted []byte
+	switch ctype {
+	case ffi.CiphertextTypePreKey:
+		pk, err := ffi.PreKeySignalMessageFromBytes(payload)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer ffi.FreePreKeySignalMessage(pk)
+
+		decrypted, err = charlie.DecryptPreKey(aliceAddr, pk)
+		if err != nil {
+			log.Fatal(err)
+		}
+	case ffi.CiphertextTypeWhisper:
+		sig, err := ffi.SignalMessageFromBytes(payload)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer ffi.FreeSignalMessage(sig)
+
+		decrypted, err = bob.DecryptSignal(aliceAddr, sig)
+		if err != nil {
+			log.Fatal(err)
+		}
+	default:
+		log.Fatalf("unexpected ciphertext type %d", ctype)
+	}
+
+	fmt.Printf("Bob decrypted: %s\n", string(decrypted))
+}

--- a/examples/go/transport/bundle.go
+++ b/examples/go/transport/bundle.go
@@ -1,0 +1,28 @@
+package transport
+
+type PreKeyEnvelope struct {
+    ID     uint32 `json:"id"`
+    Public []byte `json:"public"`
+}
+
+type SignedPreKeyEnvelope struct {
+    ID        uint32 `json:"id"`
+    Public    []byte `json:"public"`
+    Signature []byte `json:"signature"`
+}
+
+type KyberPreKeyEnvelope struct {
+    ID        uint32 `json:"id"`
+    Public    []byte `json:"public"`
+    Signature []byte `json:"signature"`
+}
+
+type BundlePayload struct {
+    RegistrationID uint32               `json:"registration_id"`
+    DeviceID       uint32               `json:"device_id"`
+    PreKey         *PreKeyEnvelope      `json:"pre_key,omitempty"`
+    SignedPreKey   SignedPreKeyEnvelope `json:"signed_pre_key"`
+    IdentityKey    []byte               `json:"identity_key"`
+    KyberPreKey    KyberPreKeyEnvelope  `json:"kyber_pre_key"`
+}
+

--- a/signal-c-binding/Cargo.toml
+++ b/signal-c-binding/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "signal-c-binding"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["staticlib"]
+
+[dependencies]
+libsignal-protocol = { workspace = true }
+libsignal-core = { workspace = true }
+rand = { workspace = true }
+futures = { workspace = true }
+log = { workspace = true }

--- a/signal-c-binding/README.md
+++ b/signal-c-binding/README.md
@@ -1,0 +1,38 @@
+# signal-c-binding
+
+Minimal C-facing shim around libsignal core types for Go experiments.
+
+## Build
+
+```
+cargo build -p signal-c-binding --release
+```
+
+## Header generation
+
+```
+cbindgen --crate signal-c-binding --output signal_c_binding.h
+```
+
+## Exposed helpers
+
+- `signalgo_identity_keypair_generate` / `signalgo_identity_keypair_free`
+- `signalgo_protocol_store_new` to construct an in-memory Signal store
+- `signalgo_store_generate_prekey_bundle` to create and retain EC/PQ pre-keys
+- `signalgo_store_process_prekey_bundle` to initialise a session from a remote bundle
+- `signalgo_store_encrypt_message`, `signalgo_store_decrypt_signal_message`, `signalgo_store_decrypt_prekey_message`
+- `signalgo_buffer_free` to release byte buffers returned by Rust
+
+## Example cgo usage
+
+```go
+// #cgo CFLAGS: -I${SRCDIR}/..
+// #cgo LDFLAGS: -L${SRCDIR}/../target/release -lsignal_c_binding -ldl -lpthread
+// #include "signal_c_binding.h"
+import "C"
+
+// Wrap the raw pointers returned from the Rust API in Go types and add
+// finalizers that call the corresponding `signalgo_*_free` routines.
+```
+
+Adjust the `cbindgen` invocation if you need a different profile. Use the generated static library (`target/release/libsignal_c_binding.a`) with cgo by adding it to `#cgo LDFLAGS` and including the header from `signal_c_binding.h`.

--- a/signal-c-binding/src/lib.rs
+++ b/signal-c-binding/src/lib.rs
@@ -1,0 +1,990 @@
+#![allow(clippy::missing_safety_doc)]
+
+use std::ffi::{CStr, c_char};
+use std::ptr;
+use std::time::{Duration, SystemTime};
+
+use futures::executor::block_on;
+use libsignal_core::{DeviceId, ProtocolAddress};
+use libsignal_protocol::{
+    CiphertextMessage, GenericSignedPreKey, IdentityKey, IdentityKeyPair, IdentityKeyStore,
+    InMemSignalProtocolStore, KeyPair, KyberPreKeyId, KyberPreKeyRecord, KyberPreKeyStore,
+    PreKeyBundle, PreKeyId, PreKeyRecord, PreKeySignalMessage, PreKeyStore, SessionStore,
+    SignalMessage, SignalProtocolError, SignedPreKeyId, SignedPreKeyRecord, SignedPreKeyStore,
+    Timestamp, UsePQRatchet, kem, message_decrypt_prekey, message_decrypt_signal, message_encrypt,
+    process_prekey_bundle,
+};
+use rand::TryRngCore as _;
+use rand::rngs::OsRng;
+
+const KYBER_KEY_TYPE: kem::KeyType = kem::KeyType::Kyber1024;
+
+// Mirror libsignal's OsRng usage so CryptoRng bounds are satisfied without
+// introducing a different entropy source over the FFI boundary.
+fn os_rng() -> impl rand::RngCore + rand::CryptoRng {
+    OsRng.unwrap_err()
+}
+
+#[repr(C)]
+pub struct SignalGoIdentityKeyPair {
+    inner: IdentityKeyPair,
+}
+
+#[repr(C)]
+pub struct SignalGoProtocolAddress {
+    inner: ProtocolAddress,
+}
+
+#[repr(C)]
+pub struct SignalGoProtocolStore {
+    inner: InMemSignalProtocolStore,
+}
+
+#[repr(C)]
+pub struct SignalGoCiphertextMessage {
+    inner: CiphertextMessage,
+}
+
+#[repr(C)]
+pub struct SignalGoSignalMessage {
+    inner: SignalMessage,
+}
+
+#[repr(C)]
+pub struct SignalGoPreKeySignalMessage {
+    inner: PreKeySignalMessage,
+}
+
+#[repr(C)]
+pub struct SignalGoPreKeyBundle {
+    inner: PreKeyBundle,
+}
+
+fn system_time_from_millis(millis: u64) -> SystemTime {
+    SystemTime::UNIX_EPOCH + Duration::from_millis(millis)
+}
+
+fn timestamp_now() -> Timestamp {
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .expect("time goes forwards");
+    Timestamp::from_epoch_millis(now.as_millis() as u64)
+}
+
+fn error_code(err: SignalProtocolError) -> i32 {
+    log::debug!("signal-c-binding error: {err:?}");
+    -1
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn signalgo_identity_keypair_generate() -> *mut SignalGoIdentityKeyPair {
+    let mut rng = os_rng();
+    let identity = IdentityKeyPair::generate(&mut rng);
+    Box::into_raw(Box::new(SignalGoIdentityKeyPair { inner: identity }))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn signalgo_identity_keypair_free(ptr: *mut SignalGoIdentityKeyPair) {
+    if ptr.is_null() {
+        return;
+    }
+    unsafe {
+        drop(Box::from_raw(ptr));
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn signalgo_identity_keypair_public_key(
+    identity: *const SignalGoIdentityKeyPair,
+    out_len: *mut usize,
+) -> *mut u8 {
+    if identity.is_null() || out_len.is_null() {
+        return ptr::null_mut();
+    }
+    let public_key = unsafe { (*identity).inner.public_key().serialize() };
+    let len = public_key.len();
+    let mut boxed = public_key;
+    let ptr = boxed.as_mut_ptr();
+    unsafe {
+        *out_len = len;
+    }
+    std::mem::forget(boxed);
+    ptr
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn signalgo_identity_keypair_private_key(
+    identity: *const SignalGoIdentityKeyPair,
+    out_len: *mut usize,
+) -> *mut u8 {
+    if identity.is_null() || out_len.is_null() {
+        return ptr::null_mut();
+    }
+    let private_key = unsafe { (*identity).inner.private_key().serialize() };
+    let len = private_key.len();
+    let mut boxed = private_key;
+    let ptr = boxed.as_mut_ptr();
+    unsafe {
+        *out_len = len;
+    }
+    std::mem::forget(boxed);
+    ptr
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn signalgo_protocol_address_new(
+    name: *const c_char,
+    device_id: u32,
+) -> *mut SignalGoProtocolAddress {
+    if name.is_null() {
+        return ptr::null_mut();
+    }
+
+    let name = unsafe { CStr::from_ptr(name) };
+    let name = match name.to_str() {
+        Ok(value) => value.to_owned(),
+        Err(_) => return ptr::null_mut(),
+    };
+
+    let device_id = match DeviceId::try_from(device_id) {
+        Ok(id) => id,
+        Err(_) => return ptr::null_mut(),
+    };
+
+    let address = ProtocolAddress::new(name, device_id);
+    Box::into_raw(Box::new(SignalGoProtocolAddress { inner: address }))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn signalgo_protocol_address_free(ptr: *mut SignalGoProtocolAddress) {
+    if ptr.is_null() {
+        return;
+    }
+    unsafe {
+        drop(Box::from_raw(ptr));
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn signalgo_protocol_store_new(
+    identity: *const SignalGoIdentityKeyPair,
+    registration_id: u32,
+) -> *mut SignalGoProtocolStore {
+    if identity.is_null() {
+        return ptr::null_mut();
+    }
+
+    let identity = unsafe { (*identity).inner };
+
+    let store = match InMemSignalProtocolStore::new(identity, registration_id) {
+        Ok(store) => store,
+        Err(_) => return ptr::null_mut(),
+    };
+
+    Box::into_raw(Box::new(SignalGoProtocolStore { inner: store }))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn signalgo_protocol_store_free(ptr: *mut SignalGoProtocolStore) {
+    if ptr.is_null() {
+        return;
+    }
+    unsafe {
+        drop(Box::from_raw(ptr));
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn signalgo_ciphertext_message_get_type(
+    message: *const SignalGoCiphertextMessage,
+) -> u8 {
+    if message.is_null() {
+        return 0;
+    }
+    let message = unsafe { &(*message).inner };
+    message.message_type() as u8
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn signalgo_ciphertext_message_serialize(
+    message: *const SignalGoCiphertextMessage,
+    out_len: *mut usize,
+) -> *mut u8 {
+    if message.is_null() || out_len.is_null() {
+        return ptr::null_mut();
+    }
+    let message = unsafe { &(*message).inner };
+    let mut bytes = message.serialize().to_vec();
+    let len = bytes.len();
+    let ptr = bytes.as_mut_ptr();
+    unsafe {
+        *out_len = len;
+    }
+    std::mem::forget(bytes);
+    ptr
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn signalgo_ciphertext_message_free(ptr: *mut SignalGoCiphertextMessage) {
+    if ptr.is_null() {
+        return;
+    }
+    unsafe {
+        drop(Box::from_raw(ptr));
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn signalgo_signal_message_from_bytes(
+    data: *const u8,
+    len: usize,
+) -> *mut SignalGoSignalMessage {
+    if data.is_null() {
+        return ptr::null_mut();
+    }
+    let data = unsafe { std::slice::from_raw_parts(data, len) };
+    match SignalMessage::try_from(data) {
+        Ok(message) => Box::into_raw(Box::new(SignalGoSignalMessage { inner: message })),
+        Err(_) => ptr::null_mut(),
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn signalgo_signal_message_free(ptr: *mut SignalGoSignalMessage) {
+    if ptr.is_null() {
+        return;
+    }
+    unsafe {
+        drop(Box::from_raw(ptr));
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn signalgo_prekey_signal_message_from_bytes(
+    data: *const u8,
+    len: usize,
+) -> *mut SignalGoPreKeySignalMessage {
+    if data.is_null() {
+        return ptr::null_mut();
+    }
+    let data = unsafe { std::slice::from_raw_parts(data, len) };
+    match PreKeySignalMessage::try_from(data) {
+        Ok(message) => Box::into_raw(Box::new(SignalGoPreKeySignalMessage { inner: message })),
+        Err(_) => ptr::null_mut(),
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn signalgo_prekey_signal_message_free(ptr: *mut SignalGoPreKeySignalMessage) {
+    if ptr.is_null() {
+        return;
+    }
+    unsafe {
+        drop(Box::from_raw(ptr));
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn signalgo_buffer_free(ptr: *mut u8, len: usize) {
+    if ptr.is_null() {
+        return;
+    }
+    unsafe {
+        Vec::from_raw_parts(ptr, len, len);
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn signalgo_store_encrypt_message(
+    store: *mut SignalGoProtocolStore,
+    address: *const SignalGoProtocolAddress,
+    plaintext: *const u8,
+    plaintext_len: usize,
+    now_millis: u64,
+    out: *mut *mut SignalGoCiphertextMessage,
+) -> i32 {
+    if store.is_null() || address.is_null() || plaintext.is_null() || out.is_null() {
+        return -1;
+    }
+
+    let plaintext = unsafe { std::slice::from_raw_parts(plaintext, plaintext_len) };
+    let store_ref = unsafe { &mut (*store).inner };
+    let address = unsafe { &(*address).inner };
+    let now = system_time_from_millis(now_millis);
+    let mut rng = os_rng();
+
+    let store_ptr: *mut InMemSignalProtocolStore = store_ref;
+
+    // The async API requires Rust futures; block here so the FFI stays synchronous.
+    let result = block_on(message_encrypt(
+        plaintext,
+        address,
+        unsafe { &mut *store_ptr } as &mut dyn SessionStore,
+        unsafe { &mut *store_ptr } as &mut dyn IdentityKeyStore,
+        now,
+        &mut rng,
+    ));
+
+    match result {
+        Ok(ciphertext) => {
+            unsafe {
+                *out = Box::into_raw(Box::new(SignalGoCiphertextMessage { inner: ciphertext }));
+            }
+            0
+        }
+        Err(err) => error_code(err),
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn signalgo_store_decrypt_signal_message(
+    store: *mut SignalGoProtocolStore,
+    address: *const SignalGoProtocolAddress,
+    message: *const SignalGoSignalMessage,
+    out_ptr: *mut *mut u8,
+    out_len: *mut usize,
+) -> i32 {
+    if store.is_null()
+        || address.is_null()
+        || message.is_null()
+        || out_ptr.is_null()
+        || out_len.is_null()
+    {
+        return -1;
+    }
+
+    let store_ref = unsafe { &mut (*store).inner };
+    let address = unsafe { &(*address).inner };
+    let message = unsafe { &(*message).inner };
+    let mut rng = os_rng();
+
+    let store_ptr: *mut InMemSignalProtocolStore = store_ref;
+
+    // Session state updates happen inside the future, so block until it completes.
+    let result = block_on(message_decrypt_signal(
+        message,
+        address,
+        unsafe { &mut *store_ptr } as &mut dyn SessionStore,
+        unsafe { &mut *store_ptr } as &mut dyn IdentityKeyStore,
+        &mut rng,
+    ));
+
+    match result {
+        Ok(mut plaintext) => {
+            let len = plaintext.len();
+            let ptr = plaintext.as_mut_ptr();
+            unsafe {
+                *out_ptr = ptr;
+                *out_len = len;
+            }
+            std::mem::forget(plaintext);
+            0
+        }
+        Err(err) => error_code(err),
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn signalgo_store_decrypt_prekey_message(
+    store: *mut SignalGoProtocolStore,
+    address: *const SignalGoProtocolAddress,
+    message: *const SignalGoPreKeySignalMessage,
+    use_pq_ratchet: bool,
+    out_ptr: *mut *mut u8,
+    out_len: *mut usize,
+) -> i32 {
+    if store.is_null()
+        || address.is_null()
+        || message.is_null()
+        || out_ptr.is_null()
+        || out_len.is_null()
+    {
+        return -1;
+    }
+
+    let store_ref = unsafe { &mut (*store).inner };
+    let address = unsafe { &(*address).inner };
+    let message = unsafe { &(*message).inner };
+    let mut rng = os_rng();
+
+    let store_ptr: *mut InMemSignalProtocolStore = store_ref;
+
+    // Pre-key decrypt touches multiple stores; block so we can return the plaintext.
+    let result = block_on(message_decrypt_prekey(
+        message,
+        address,
+        unsafe { &mut *store_ptr } as &mut dyn SessionStore,
+        unsafe { &mut *store_ptr } as &mut dyn IdentityKeyStore,
+        unsafe { &mut *store_ptr } as &mut dyn PreKeyStore,
+        unsafe { &mut *store_ptr } as &mut dyn SignedPreKeyStore,
+        unsafe { &mut *store_ptr } as &mut dyn KyberPreKeyStore,
+        &mut rng,
+        UsePQRatchet::from(use_pq_ratchet),
+    ));
+
+    match result {
+        Ok(mut plaintext) => {
+            let len = plaintext.len();
+            let ptr = plaintext.as_mut_ptr();
+            unsafe {
+                *out_ptr = ptr;
+                *out_len = len;
+            }
+            std::mem::forget(plaintext);
+            0
+        }
+        Err(err) => error_code(err),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+#[unsafe(no_mangle)]
+pub extern "C" fn signalgo_store_generate_prekey_bundle(
+    store: *mut SignalGoProtocolStore,
+    registration_id: u32,
+    device_id: u32,
+    prekey_id: u32,
+    signed_prekey_id: u32,
+    kyber_prekey_id: u32,
+    out_bundle: *mut *mut SignalGoPreKeyBundle,
+) -> i32 {
+    if store.is_null() || out_bundle.is_null() {
+        return -1;
+    }
+
+    let store_ref = unsafe { &mut (*store).inner };
+
+    // Grab the identity key first; it signs both EC and Kyber pre-keys we publish.
+    let identity = match block_on(store_ref.get_identity_key_pair()) {
+        Ok(identity) => identity,
+        Err(err) => return error_code(err),
+    };
+
+    let mut rng = os_rng();
+
+    // Generate one-time EC pre-key
+    let ec_pre_key_pair = KeyPair::generate(&mut rng);
+    let pre_key_id = PreKeyId::from(prekey_id);
+    let pre_key_record = PreKeyRecord::new(pre_key_id, &ec_pre_key_pair);
+    if let Err(err) = block_on(store_ref.save_pre_key(pre_key_id, &pre_key_record)) {
+        return error_code(err);
+    }
+
+    // Signed pre-key
+    let signed_pre_key_pair = KeyPair::generate(&mut rng);
+    let signature = match identity
+        .private_key()
+        .calculate_signature(&signed_pre_key_pair.public_key.serialize(), &mut rng)
+    {
+        Ok(sig) => sig,
+        Err(_) => return -1,
+    };
+    let signature = signature.into_vec();
+    let timestamp = timestamp_now();
+    let signed_pre_key_id = SignedPreKeyId::from(signed_prekey_id);
+    let signed_pre_key_record = SignedPreKeyRecord::new(
+        signed_pre_key_id,
+        timestamp,
+        &signed_pre_key_pair,
+        &signature,
+    );
+    if let Err(err) =
+        block_on(store_ref.save_signed_pre_key(signed_pre_key_id, &signed_pre_key_record))
+    {
+        return error_code(err);
+    }
+
+    // Kyber pre-key
+    let kyber_pre_key_id = KyberPreKeyId::from(kyber_prekey_id);
+    let kyber_pre_key_record =
+        match KyberPreKeyRecord::generate(KYBER_KEY_TYPE, kyber_pre_key_id, identity.private_key())
+        {
+            Ok(record) => record,
+            Err(_) => return -1,
+        };
+    if let Err(err) =
+        block_on(store_ref.save_kyber_pre_key(kyber_pre_key_id, &kyber_pre_key_record))
+    {
+        return error_code(err);
+    }
+
+    let device_id = match DeviceId::try_from(device_id) {
+        Ok(id) => id,
+        Err(_) => return -1,
+    };
+
+    let prekey_public = match pre_key_record.public_key() {
+        Ok(key) => key,
+        Err(err) => return error_code(err),
+    };
+
+    let signed_prekey_signature = signature.clone();
+
+    let kyber_public = match kyber_pre_key_record.public_key() {
+        Ok(key) => key.clone(),
+        Err(err) => return error_code(err),
+    };
+    let kyber_signature = match kyber_pre_key_record.signature() {
+        Ok(sig) => sig,
+        Err(err) => return error_code(err),
+    };
+
+    let bundle = match PreKeyBundle::new(
+        registration_id,
+        device_id,
+        Some((pre_key_id, prekey_public)),
+        signed_pre_key_id,
+        signed_pre_key_pair.public_key,
+        signed_prekey_signature,
+        kyber_pre_key_id,
+        kyber_public,
+        kyber_signature,
+        IdentityKey::new(*identity.public_key()),
+    ) {
+        Ok(bundle) => bundle,
+        Err(err) => return error_code(err),
+    };
+
+    unsafe {
+        *out_bundle = Box::into_raw(Box::new(SignalGoPreKeyBundle { inner: bundle }));
+    }
+
+    0
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn signalgo_prekey_bundle_free(ptr: *mut SignalGoPreKeyBundle) {
+    if ptr.is_null() {
+        return;
+    }
+    unsafe {
+        drop(Box::from_raw(ptr));
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn signalgo_prekey_bundle_get_registration_id(
+    bundle: *const SignalGoPreKeyBundle,
+    out: *mut u32,
+) -> i32 {
+    if bundle.is_null() || out.is_null() {
+        return -1;
+    }
+
+    let registration_id = match unsafe { (*bundle).inner.registration_id() } {
+        Ok(value) => value,
+        Err(err) => return error_code(err),
+    };
+
+    unsafe {
+        *out = registration_id;
+    }
+
+    0
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn signalgo_prekey_bundle_get_device_id(
+    bundle: *const SignalGoPreKeyBundle,
+    out: *mut u32,
+) -> i32 {
+    if bundle.is_null() || out.is_null() {
+        return -1;
+    }
+
+    let device_id = match unsafe { (*bundle).inner.device_id() } {
+        Ok(value) => value,
+        Err(err) => return error_code(err),
+    };
+
+    unsafe {
+        *out = u32::from(device_id);
+    }
+
+    0
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn signalgo_prekey_bundle_get_prekey_id(
+    bundle: *const SignalGoPreKeyBundle,
+    present: *mut bool,
+    out_id: *mut u32,
+) -> i32 {
+    if bundle.is_null() || present.is_null() || out_id.is_null() {
+        return -1;
+    }
+
+    let pre_key_id = match unsafe { (*bundle).inner.pre_key_id() } {
+        Ok(value) => value,
+        Err(err) => return error_code(err),
+    };
+
+    unsafe {
+        match pre_key_id {
+            Some(id) => {
+                *present = true;
+                *out_id = id.into();
+            }
+            None => {
+                *present = false;
+                *out_id = 0;
+            }
+        }
+    }
+
+    0
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn signalgo_prekey_bundle_get_prekey_public(
+    bundle: *const SignalGoPreKeyBundle,
+    out_ptr: *mut *mut u8,
+    out_len: *mut usize,
+) -> i32 {
+    if bundle.is_null() || out_ptr.is_null() || out_len.is_null() {
+        return -1;
+    }
+
+    let key = match unsafe { (*bundle).inner.pre_key_public() } {
+        Ok(value) => value,
+        Err(err) => return error_code(err),
+    };
+
+    match key {
+        Some(public_key) => {
+            let mut bytes = public_key.serialize();
+            let len = bytes.len();
+            let ptr = bytes.as_mut_ptr();
+            unsafe {
+                *out_ptr = ptr;
+                *out_len = len;
+            }
+            std::mem::forget(bytes);
+        }
+        None => unsafe {
+            *out_ptr = ptr::null_mut();
+            *out_len = 0;
+        },
+    }
+
+    0
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn signalgo_prekey_bundle_get_signed_prekey_id(
+    bundle: *const SignalGoPreKeyBundle,
+    out: *mut u32,
+) -> i32 {
+    if bundle.is_null() || out.is_null() {
+        return -1;
+    }
+
+    let id = match unsafe { (*bundle).inner.signed_pre_key_id() } {
+        Ok(value) => value,
+        Err(err) => return error_code(err),
+    };
+
+    unsafe {
+        *out = id.into();
+    }
+
+    0
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn signalgo_prekey_bundle_get_signed_prekey_public(
+    bundle: *const SignalGoPreKeyBundle,
+    out_ptr: *mut *mut u8,
+    out_len: *mut usize,
+) -> i32 {
+    if bundle.is_null() || out_ptr.is_null() || out_len.is_null() {
+        return -1;
+    }
+
+    let public_key = match unsafe { (*bundle).inner.signed_pre_key_public() } {
+        Ok(value) => value,
+        Err(err) => return error_code(err),
+    };
+
+    let mut bytes = public_key.serialize();
+    let len = bytes.len();
+    let ptr = bytes.as_mut_ptr();
+    unsafe {
+        *out_ptr = ptr;
+        *out_len = len;
+    }
+    std::mem::forget(bytes);
+    0
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn signalgo_prekey_bundle_get_signed_prekey_signature(
+    bundle: *const SignalGoPreKeyBundle,
+    out_ptr: *mut *mut u8,
+    out_len: *mut usize,
+) -> i32 {
+    if bundle.is_null() || out_ptr.is_null() || out_len.is_null() {
+        return -1;
+    }
+
+    let signature = match unsafe { (*bundle).inner.signed_pre_key_signature() } {
+        Ok(value) => value,
+        Err(err) => return error_code(err),
+    };
+
+    let mut bytes = signature.to_vec().into_boxed_slice();
+    let len = bytes.len();
+    let ptr = bytes.as_mut_ptr();
+    unsafe {
+        *out_ptr = ptr;
+        *out_len = len;
+    }
+    std::mem::forget(bytes);
+    0
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn signalgo_prekey_bundle_get_identity_key(
+    bundle: *const SignalGoPreKeyBundle,
+    out_ptr: *mut *mut u8,
+    out_len: *mut usize,
+) -> i32 {
+    if bundle.is_null() || out_ptr.is_null() || out_len.is_null() {
+        return -1;
+    }
+
+    let identity_key = match unsafe { (*bundle).inner.identity_key() } {
+        Ok(value) => value,
+        Err(err) => return error_code(err),
+    };
+
+    let mut bytes = identity_key.serialize();
+    let len = bytes.len();
+    let ptr = bytes.as_mut_ptr();
+    unsafe {
+        *out_ptr = ptr;
+        *out_len = len;
+    }
+    std::mem::forget(bytes);
+    0
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn signalgo_prekey_bundle_get_kyber_prekey_id(
+    bundle: *const SignalGoPreKeyBundle,
+    out: *mut u32,
+) -> i32 {
+    if bundle.is_null() || out.is_null() {
+        return -1;
+    }
+
+    let id = match unsafe { (*bundle).inner.kyber_pre_key_id() } {
+        Ok(value) => value,
+        Err(err) => return error_code(err),
+    };
+
+    unsafe {
+        *out = id.into();
+    }
+
+    0
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn signalgo_prekey_bundle_get_kyber_prekey_public(
+    bundle: *const SignalGoPreKeyBundle,
+    out_ptr: *mut *mut u8,
+    out_len: *mut usize,
+) -> i32 {
+    if bundle.is_null() || out_ptr.is_null() || out_len.is_null() {
+        return -1;
+    }
+
+    let public_key = match unsafe { (*bundle).inner.kyber_pre_key_public() } {
+        Ok(value) => value,
+        Err(err) => return error_code(err),
+    };
+
+    let mut bytes = public_key.serialize();
+    let len = bytes.len();
+    let ptr = bytes.as_mut_ptr();
+    unsafe {
+        *out_ptr = ptr;
+        *out_len = len;
+    }
+    std::mem::forget(bytes);
+    0
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn signalgo_prekey_bundle_get_kyber_prekey_signature(
+    bundle: *const SignalGoPreKeyBundle,
+    out_ptr: *mut *mut u8,
+    out_len: *mut usize,
+) -> i32 {
+    if bundle.is_null() || out_ptr.is_null() || out_len.is_null() {
+        return -1;
+    }
+
+    let signature = match unsafe { (*bundle).inner.kyber_pre_key_signature() } {
+        Ok(value) => value,
+        Err(err) => return error_code(err),
+    };
+
+    let mut bytes = signature.to_vec().into_boxed_slice();
+    let len = bytes.len();
+    let ptr = bytes.as_mut_ptr();
+    unsafe {
+        *out_ptr = ptr;
+        *out_len = len;
+    }
+    std::mem::forget(bytes);
+    0
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn signalgo_prekey_bundle_from_parts(
+    registration_id: u32,
+    device_id: u32,
+    has_pre_key: bool,
+    pre_key_id: u32,
+    pre_key_public: *const u8,
+    pre_key_public_len: usize,
+    signed_pre_key_id: u32,
+    signed_pre_key_public: *const u8,
+    signed_pre_key_public_len: usize,
+    signed_pre_key_signature: *const u8,
+    signed_pre_key_signature_len: usize,
+    identity_key: *const u8,
+    identity_key_len: usize,
+    kyber_pre_key_id: u32,
+    kyber_pre_key_public: *const u8,
+    kyber_pre_key_public_len: usize,
+    kyber_pre_key_signature: *const u8,
+    kyber_pre_key_signature_len: usize,
+    out_bundle: *mut *mut SignalGoPreKeyBundle,
+) -> i32 {
+    if out_bundle.is_null() {
+        return -1;
+    }
+
+    if signed_pre_key_public.is_null()
+        || signed_pre_key_signature.is_null()
+        || identity_key.is_null()
+        || kyber_pre_key_public.is_null()
+        || kyber_pre_key_signature.is_null()
+    {
+        return -1;
+    }
+
+    let device_id = match DeviceId::try_from(device_id) {
+        Ok(id) => id,
+        Err(_) => return -1,
+    };
+
+    let signed_pre_key_id = SignedPreKeyId::from(signed_pre_key_id);
+    let kyber_pre_key_id = KyberPreKeyId::from(kyber_pre_key_id);
+
+    let signed_pre_key_public =
+        unsafe { std::slice::from_raw_parts(signed_pre_key_public, signed_pre_key_public_len) };
+    let signed_pre_key_public = match libsignal_protocol::PublicKey::try_from(signed_pre_key_public)
+    {
+        Ok(value) => value,
+        Err(err) => return error_code(err.into()),
+    };
+
+    let signed_pre_key_signature = unsafe {
+        std::slice::from_raw_parts(signed_pre_key_signature, signed_pre_key_signature_len)
+    }
+    .to_vec();
+
+    let identity_key_bytes = unsafe { std::slice::from_raw_parts(identity_key, identity_key_len) };
+    let identity_key = match IdentityKey::try_from(identity_key_bytes) {
+        Ok(value) => value,
+        Err(err) => return error_code(err),
+    };
+
+    let kyber_pre_key_public =
+        unsafe { std::slice::from_raw_parts(kyber_pre_key_public, kyber_pre_key_public_len) };
+    let kyber_pre_key_public = match kem::PublicKey::deserialize(kyber_pre_key_public) {
+        Ok(value) => value,
+        Err(err) => return error_code(err),
+    };
+
+    let kyber_pre_key_signature =
+        unsafe { std::slice::from_raw_parts(kyber_pre_key_signature, kyber_pre_key_signature_len) }
+            .to_vec();
+
+    let pre_key = if has_pre_key {
+        if pre_key_public.is_null() {
+            return -1;
+        }
+        let pre_key_public =
+            unsafe { std::slice::from_raw_parts(pre_key_public, pre_key_public_len) };
+        let pre_key_public = match libsignal_protocol::PublicKey::try_from(pre_key_public) {
+            Ok(value) => value,
+            Err(err) => return error_code(err.into()),
+        };
+        Some((PreKeyId::from(pre_key_id), pre_key_public))
+    } else {
+        None
+    };
+
+    let bundle = match PreKeyBundle::new(
+        registration_id,
+        device_id,
+        pre_key,
+        signed_pre_key_id,
+        signed_pre_key_public,
+        signed_pre_key_signature,
+        kyber_pre_key_id,
+        kyber_pre_key_public,
+        kyber_pre_key_signature,
+        identity_key,
+    ) {
+        Ok(bundle) => bundle,
+        Err(err) => return error_code(err),
+    };
+
+    unsafe {
+        *out_bundle = Box::into_raw(Box::new(SignalGoPreKeyBundle { inner: bundle }));
+    }
+
+    0
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn signalgo_store_process_prekey_bundle(
+    store: *mut SignalGoProtocolStore,
+    address: *const SignalGoProtocolAddress,
+    bundle: *const SignalGoPreKeyBundle,
+    now_millis: u64,
+    use_pq_ratchet: bool,
+) -> i32 {
+    if store.is_null() || address.is_null() || bundle.is_null() {
+        return -1;
+    }
+
+    let store_ref = unsafe { &mut (*store).inner };
+    let address = unsafe { &(*address).inner };
+    let bundle = unsafe { &(*bundle).inner };
+    let now = system_time_from_millis(now_millis);
+    let mut rng = os_rng();
+
+    let store_ptr: *mut InMemSignalProtocolStore = store_ref;
+
+    let result = block_on(process_prekey_bundle(
+        address,
+        unsafe { &mut *store_ptr } as &mut dyn SessionStore,
+        unsafe { &mut *store_ptr } as &mut dyn IdentityKeyStore,
+        bundle,
+        now,
+        &mut rng,
+        UsePQRatchet::from(use_pq_ratchet),
+    ));
+
+    match result {
+        Ok(()) => 0,
+        Err(err) => error_code(err),
+    }
+}


### PR DESCRIPTION
- added signal-c-binding crate for generating c-bindings from rust code
- created an example project in examples/go
	- examples/go/main.go - simple encrypt and decrypt
	- examples/go/cmd/server/ - runs a simple http server that servers `register`,`login`, `add message` and `drain message` features
	- examples/go/cmd/client/ - runs a client application that allows user session creation and messsage exchange through sample server created above