### PR TITLE
perf(podspec): Replace always_out_of_date with input/output file declarations

### DIFF
--- a/LibSignalClient.podspec
+++ b/LibSignalClient.podspec
@@ -22,6 +22,7 @@ Pod::Spec.new do |s|
     'swift/Sources/SignalFfi',
     'bin/fetch_archive.py',
     'acknowledgments/acknowledgments-ios.plist',
+    'LibSignalClient.podspec',
   ]
 
   pod_target_xcconfig = {
@@ -70,11 +71,8 @@ Pod::Spec.new do |s|
   s.script_phases = [
     { name: 'Download libsignal-ffi if not in cache',
       execution_position: :before_compile,
-      # It's not *ideal* to check the cache every build, but it's usually just a shasum.
-      # It might be possible to rely on the relative mtimes of the podspec and the fetched archive,
-      # but I wouldn't want to risk a mismatched archive giving us cryptic errors at link or run
-      # time later. This Is Fine.
-      always_out_of_date: '1',
+      input_files: ['$(PODS_TARGET_SRCROOT)/LibSignalClient.podspec'],
+      output_files: ['$(USER_LIBRARY_DIR)/Caches/org.signal.libsignal/$(LIBSIGNAL_FFI_PREBUILD_ARCHIVE)'],
       script: %q(
         set -euo pipefail
         if [ -e "${PODS_TARGET_SRCROOT}/swift/build_ffi.sh" ]; then


### PR DESCRIPTION
## Summary

Remove `always_out_of_date: '1'` from the download script phase and add proper `input_files`/`output_files` declarations. This allows Xcode to cache build artifacts properly.

## Performance Impact (measured with [Argus](https://github.com/tuist/argus))

| Metric | Before | After |
|--------|--------|-------|
| Build time | 99s | 16s |
| Cache hits | 0.1% (4/3555) | 91.3% (2789/3054) |

**6x faster incremental builds for Signal-iOS.**

## Safety

The original concern was avoiding mismatched archives causing cryptic runtime errors. This is already handled by:

1. **Checksum verification** - `fetch_archive.py -c` verifies SHA256. Corrupted/wrong archives fail the build immediately.
2. **Podspec-as-input** - Any version/checksum change modifies the podspec, triggering re-download.
3. **Extract phase dependency** - If archive is missing, Extract phase fails, forcing rebuild.

## The Problem

`always_out_of_date: '1'` doesn't just re-run the download script - it invalidates Xcode's entire compilation cache for all downstream targets. The script itself is fast (just a checksum), but the cascading cache invalidation causes 0.1% cache hits on incremental builds.

## Testing

Tested on Signal-iOS SignalServiceKit scheme with local libsignal dependency.