### PR TITLE
keytrans: Validate tree_size and pos before using

### DIFF
--- a/rust/keytrans/src/implicit.rs
+++ b/rust/keytrans/src/implicit.rs
@@ -163,4 +163,26 @@ mod test {
             let _ = root(start, n);
         });
     }
+
+    // These functions require `start < n`. Callers in `verify.rs` validate
+    // `tree_size` and `pos` against `MAX_TREE_SIZE` and each other before
+    // reaching this module.
+
+    #[test]
+    #[should_panic(expected = "leaf node has no children")]
+    fn precondition_frontier_panics_on_zero_n() {
+        let _ = frontier(0, 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "leaf node has no children")]
+    fn precondition_root_panics_when_start_equals_n() {
+        let _ = root(1, 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "leaf node has no children")]
+    fn precondition_root_panics_when_start_exceeds_n() {
+        let _ = root(10, 5);
+    }
 }

--- a/rust/keytrans/src/log.rs
+++ b/rust/keytrans/src/log.rs
@@ -206,6 +206,29 @@ mod math {
             assert_eq!(batch_copath(&[0, 2, 3, 4], 8), vec![2, 10, 13]);
             assert_eq!(batch_copath(&[0, 2, 3], 8), vec![2, 11]);
         }
+
+        // `node_width(n) = 2*(n-1)+1` overflows for `n > 2^63`. Callers in
+        // `verify.rs` bound `tree_size` by `MAX_TREE_SIZE` (`2^62`) before
+        // reaching this module.
+
+        #[test]
+        #[should_panic(expected = "attempt to multiply with overflow")]
+        fn precondition_node_width_panics_above_2_63() {
+            let _ = node_width((1u64 << 63) + 1);
+        }
+
+        #[test]
+        #[should_panic(expected = "attempt to multiply with overflow")]
+        fn precondition_root_panics_above_2_63() {
+            let _ = root((1u64 << 63) + 1);
+        }
+
+        #[test]
+        fn node_width_safe_at_max_tree_size() {
+            // MAX_TREE_SIZE = 2^62; node_width(2^62) = 2^63 - 1 fits in u64.
+            let _ = node_width(1u64 << 62);
+            let _ = root(1u64 << 62);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

A malformed Key Transparency server response (tree_size = 0, pos >= tree_size, or tree_size > 2^63) could panic the functions using those values to navigate the Key Transparency tree. This changes adds range checks in verify_search_internal and verify_monitor before the key transparency tree is navigated.

## Details 

The tree-navigation functions in `implicit.rs` and `log.rs` have an implicit precondition `0 < tree_size ∧ pos < tree_size` that is **assumed but not validated** when called from `verify_search_internal`:
[rust/keytrans/src/implicit.rs:130
](https://github.com/signalapp/libsignal/blob/main/rust/keytrans/src/implicit.rs#L130
)
```rust
```rust
prop_compose! {
    fn start_and_n()(n in 0..=u64::MAX)(start in 0..n, n in Just(n)) -> StartAndN {
        //                              ^^^^^^^^^^^^^ requires start < n
        StartAndN { start, n }
    }
}
```

[rust/keytrans/src/verify.rs:463-469](https://github.com/signalapp/libsignal/blob/main/rust/keytrans/src/verify.rs#L463)
```rust
let tree_size = {
    let tree_head = get_proto_field(&full_tree_head.tree_head, "tree_head")?;
    tree_head.tree_size              // uint64 from protobuf, unvalidated
};
let search_proof = get_proto_field(&search, "search")?;
let guide = ProofGuide::new(version, search_proof.pos, tree_size);
//                                   ^^^^^^^^^^^^^^^^  ^^^^^^^^^ both server-controlled
```

Signature verification happens later in [rust/keytrans/src/verify.rs:537](https://github.com/signalapp/libsignal/blob/main/rust/keytrans/src/verify.rs#L537):
```rust
// rust/keytrans/src/verify.rs:537
let updated_tree_head = verify_full_tree_head(config, full_tree_head, root, ...)?;
// ↑ never reached if ProofGuide::new panics
```
