### PR TITLE
doc: Remove `multilingual` key

### DIFF
--- a/doc/book.toml
+++ b/doc/book.toml
@@ -1,4 +1,3 @@
 [book]
 language = "en"
-multilingual = false
 title = "libsignal"


### PR DESCRIPTION
This key was removed in mdBook 0.5.

According to the changelog:
> - Removed the `book.multilingual` field. This was never used.
>   [#2775](https://github.com/rust-lang/mdBook/pull/2775)

See also: <https://github.com/rust-lang/mdBook/pull/2775>