### PR TITLE
Respect custom Cargo target dir in JNI build

### DIFF
--- a/bin/build_helpers.sh
+++ b/bin/build_helpers.sh
@@ -74,3 +74,8 @@ rust_remap_path_options() {
     echo -n "--remap-path-prefix ${prefix}= "
   done
 }
+
+cargo_target_directory() {
+  cargo metadata --format-version 1 --no-deps --offline |
+    python3 -c 'import json, sys; print(json.load(sys.stdin)["target_directory"])'
+}

--- a/java/build_jni.sh
+++ b/java/build_jni.sh
@@ -19,6 +19,7 @@ SERVER_LIB_DIR=java/server/src/main/resources
 # Fetch dependencies first, so we can use them in computing later options.
 # But allow this to fail in case we're offline.
 cargo fetch || true
+CARGO_TARGET_DIRECTORY=$(cargo_target_directory)
 
 export CARGO_PROFILE_RELEASE_DEBUG=1 # Enable line tables
 RUSTFLAGS="--cfg aes_armv8 ${RUSTFLAGS:-}" # Enable ARMv8 cryptography acceleration when available
@@ -137,8 +138,8 @@ build_desktop_for_arch () {
     fi
 
     echo_then_run cargo build -p libsignal-jni -p libsignal-jni-testing ${RUST_RELEASE:+--release} ${FEATURES:+--features "${FEATURES[*]}"} --target "$1"
-    copy_built_library "target/${1}/${RUST_RELEASE:-debug}" signal_jni "$lib_dir" "signal_jni_${suffix}"
-    copy_built_library "target/${1}/${RUST_RELEASE:-debug}" signal_jni_testing "$lib_dir" "signal_jni_testing_${suffix}"
+    copy_built_library "${CARGO_TARGET_DIRECTORY}/${1}/${RUST_RELEASE:-debug}" signal_jni "$lib_dir" "signal_jni_${suffix}"
+    copy_built_library "${CARGO_TARGET_DIRECTORY}/${1}/${RUST_RELEASE:-debug}" signal_jni_testing "$lib_dir" "signal_jni_testing_${suffix}"
     check_for_debug_level_logs_if_needed "$lib_dir"
 }
 
@@ -159,12 +160,12 @@ while [ "${1:-}" != "" ]; do
             export CARGO_PROFILE_RELEASE_LTO=thin
             host_triple=$(rustc -vV | sed -n 's|host: ||p')
             if [[ "$1" == "server-all" ]]; then
-                build_desktop_for_arch x86_64-unknown-linux-gnu "$host_triple" $lib_dir
+                build_desktop_for_arch x86_64-unknown-linux-gnu "$host_triple" "$lib_dir"
                 # Enable ARMv8.2 extensions for a production aarch64 server build
                 RUSTFLAGS="-C target-feature=+v8.2a ${RUSTFLAGS:-}" \
-                    build_desktop_for_arch aarch64-unknown-linux-gnu "$host_triple" $lib_dir
+                    build_desktop_for_arch aarch64-unknown-linux-gnu "$host_triple" "$lib_dir"
             else
-                build_desktop_for_arch "${CARGO_BUILD_TARGET:-$host_triple}" "$host_triple" $lib_dir
+                build_desktop_for_arch "${CARGO_BUILD_TARGET:-$host_triple}" "$host_triple" "$lib_dir"
             fi
             exit
             ;;


### PR DESCRIPTION
## Summary
- resolve Cargo's actual target directory with `cargo metadata`
- copy desktop/server JNI libraries from that resolved directory instead of hard-coded `target/...`
- keep Android artifact handling unchanged because it already uses `--artifact-dir`

## Why
`java/build_jni.sh` respected Cargo's configured target directory during the build, but then copied desktop/server libraries from `target/$triple/...`. That breaks users who set `CARGO_TARGET_DIR` or configure `build.target-dir`, as reported in #655.

## Validation
- `bash -n bin/build_helpers.sh java/build_jni.sh`
- `git diff --check`
- fake-toolchain smoke: ran `java/build_jni.sh desktop` with a fake `cargo`/`rustc` and `CARGO_TARGET_DIR` set to a temp custom directory; the script copied `libsignal_jni_amd64.dylib` and `libsignal_jni_testing_amd64.dylib` from that custom target directory into `java/client/src/main/resources`

I could not run the full Rust/JNI build in this local environment because `cargo` is not installed on this machine.

Fixes #655.
