### PR TITLE
Fix poksho squeeze overflow

### DIFF
--- a/rust/poksho/src/shohmacsha256.rs
+++ b/rust/poksho/src/shohmacsha256.rs
@@ -65,13 +65,13 @@ impl ShoApi for ShoHmacSha256 {
         let outlen = target.len();
         let output_hasher_prefix =
             Hmac::<Sha256>::new_from_slice(&self.cv).expect("HMAC accepts 256-bit keys");
-        let mut i = 0;
-        while i * HASH_LEN < outlen {
+        let mut i = 0u64;
+        while !target.is_empty() {
             let mut output_hasher = output_hasher_prefix.clone();
-            output_hasher.update(&(i as u64).to_be_bytes());
+            output_hasher.update(&i.to_be_bytes());
             output_hasher.update(&[0x01]);
             let digest = output_hasher.finalize().into_bytes();
-            let num_bytes = cmp::min(HASH_LEN, outlen - i * HASH_LEN);
+            let num_bytes = cmp::min(HASH_LEN, target.len());
             let (output, tail) = target.split_at_mut(num_bytes);
             output.copy_from_slice(&digest[..num_bytes]);
             target = tail;

--- a/rust/poksho/src/shosha256.rs
+++ b/rust/poksho/src/shosha256.rs
@@ -68,14 +68,14 @@ impl ShoApi for ShoSha256 {
         output_hasher_prefix.update(&[0u8; BLOCK_LEN - 1][..]);
         output_hasher_prefix.update(&[1u8][..]); // domain separator byte
         output_hasher_prefix.update(self.cv);
-        let mut i = 0;
         let outlen = target.len();
 
-        while i * HASH_LEN < outlen {
+        let mut i = 0u64;
+        while !target.is_empty() {
             let mut output_hasher = output_hasher_prefix.clone();
-            output_hasher.update((i as u64).to_be_bytes());
+            output_hasher.update(i.to_be_bytes());
             let digest = output_hasher.finalize();
-            let num_bytes = cmp::min(HASH_LEN, outlen - i * HASH_LEN);
+            let num_bytes = cmp::min(HASH_LEN, target.len());
             let (output, tail) = target.split_at_mut(num_bytes);
             output.copy_from_slice(&digest[0..num_bytes]);
             target = tail;


### PR DESCRIPTION
## summary

fixes #480

- avoid `i * HASH_LEN` in the SHO squeeze loops
- iterate over the remaining output buffer instead, so the loop cannot overflow before the final block
- keep the same `u64` block counter encoding and final ratchet length

## testing

- `cargo test -p poksho`
- `cargo test -p poksho --all-features`
- `cargo test -p poksho --release`
- `cargo clippy -p poksho --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --keep-going -- -D warnings`
- `git diff --check`
