### PR TITLE
poksho: Avoid theoretical overflow in squeeze_and_ratchet

### DIFF
--- a/rust/poksho/src/shohmacsha256.rs
+++ b/rust/poksho/src/shohmacsha256.rs
@@ -3,8 +3,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-use std::cmp;
-
 use hmac::{Hmac, Mac};
 use sha2::Sha256;
 
@@ -60,22 +58,20 @@ impl ShoApi for ShoHmacSha256 {
         self.mode = Mode::RATCHETED;
     }
 
-    fn squeeze_and_ratchet_into(&mut self, mut target: &mut [u8]) {
+    fn squeeze_and_ratchet_into(&mut self, target: &mut [u8]) {
         assert!(self.mode == Mode::RATCHETED);
         let outlen = target.len();
         let output_hasher_prefix =
             Hmac::<Sha256>::new_from_slice(&self.cv).expect("HMAC accepts 256-bit keys");
-        let mut i = 0;
-        while i * HASH_LEN < outlen {
+
+        // Iterating over chunks (rather than computing `i * HASH_LEN`) avoids a
+        // theoretical `usize` multiplication overflow for very large `outlen`.
+        for (i, chunk) in target.chunks_mut(HASH_LEN).enumerate() {
             let mut output_hasher = output_hasher_prefix.clone();
             output_hasher.update(&(i as u64).to_be_bytes());
             output_hasher.update(&[0x01]);
             let digest = output_hasher.finalize().into_bytes();
-            let num_bytes = cmp::min(HASH_LEN, outlen - i * HASH_LEN);
-            let (output, tail) = target.split_at_mut(num_bytes);
-            output.copy_from_slice(&digest[..num_bytes]);
-            target = tail;
-            i += 1
+            chunk.copy_from_slice(&digest[..chunk.len()]);
         }
 
         let mut next_hasher = output_hasher_prefix;

--- a/rust/poksho/src/shosha256.rs
+++ b/rust/poksho/src/shosha256.rs
@@ -5,8 +5,6 @@
 
 // implements the "innerpad" SHO/SHA256 proposal
 
-use std::cmp;
-
 use sha2::{Digest, Sha256};
 
 use crate::shoapi::ShoApi;
@@ -61,25 +59,22 @@ impl ShoApi for ShoSha256 {
         self.mode = Mode::RATCHETED;
     }
 
-    fn squeeze_and_ratchet_into(&mut self, mut target: &mut [u8]) {
+    fn squeeze_and_ratchet_into(&mut self, target: &mut [u8]) {
         assert!(self.mode == Mode::RATCHETED);
         let mut output_hasher_prefix = Sha256::new();
         // Explicitly pass a slice to avoid generating multiple versions of update().
         output_hasher_prefix.update(&[0u8; BLOCK_LEN - 1][..]);
         output_hasher_prefix.update(&[1u8][..]); // domain separator byte
         output_hasher_prefix.update(self.cv);
-        let mut i = 0;
         let outlen = target.len();
 
-        while i * HASH_LEN < outlen {
+        // Iterating over chunks (rather than computing `i * HASH_LEN`) avoids a
+        // theoretical `usize` multiplication overflow for very large `outlen`.
+        for (i, chunk) in target.chunks_mut(HASH_LEN).enumerate() {
             let mut output_hasher = output_hasher_prefix.clone();
             output_hasher.update((i as u64).to_be_bytes());
             let digest = output_hasher.finalize();
-            let num_bytes = cmp::min(HASH_LEN, outlen - i * HASH_LEN);
-            let (output, tail) = target.split_at_mut(num_bytes);
-            output.copy_from_slice(&digest[0..num_bytes]);
-            target = tail;
-            i += 1
+            chunk.copy_from_slice(&digest[..chunk.len()]);
         }
 
         let mut next_hasher = Sha256::new();


### PR DESCRIPTION
Fixes #480.

## Problem

Both `ShoSha256` and `ShoHmacSha256` drive `squeeze_and_ratchet_into` with:

```rust
while i * HASH_LEN < outlen { ... }
```

For an extremely large `outlen`, `i * HASH_LEN` can overflow `usize`, panicking in debug builds or producing a runaway memory-eating loop in release builds. As noted in the issue, this is unreachable in any practical scenario (and at worst a DoS), but it's still a latent footgun.

## Fix

Iterate over `target.chunks_mut(HASH_LEN).enumerate()` instead. This removes the `i * HASH_LEN` multiplication entirely — and with it the `outlen - i * HASH_LEN` subtraction for the final partial chunk, which becomes just `chunk.len()`. The manual `split_at_mut` plumbing and the now-unused `std::cmp` import go away too.

## Why it's safe

- The block counter `i` fed into the hash (`(i as u64).to_be_bytes()`) is unchanged.
- The number of bytes copied per chunk is unchanged.
- An empty `target` yields zero chunks, matching the old `0 * HASH_LEN < 0` being false.

Output is therefore byte-identical. The existing `test_vectors` tests (which assert exact output for lengths 63/64/65/127/128/129 plus chained ratchets) still pass:

```
running 5 tests
test statement::tests::test_statement_encoding ... ok
test shosha256::tests::test_vectors ... ok
test shohmacsha256::tests::test_vectors ... ok
test sign::tests::test_signature ... ok
test statement::tests::test_complex_statement ... ok

test result: ok. 5 passed; 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)