### PR TITLE
build: Honor CARGO_TARGET_DIR in client build scripts

### DIFF
--- a/bin/build_helpers.sh
+++ b/bin/build_helpers.sh
@@ -49,9 +49,11 @@ copy_built_library() {
       out_dir=$(dirname "$3"x) # trailing x to distinguish directories from files
       echo_then_run mkdir -p "${out_dir}"
       echo_then_run cp "${possible_library_path}" "$3/${possible_augmented_name}"
-      break
+      return
     fi
   done
+  echo "error: no built library '${2}' found in '${1}' (looked for lib${2}.dylib, lib${2}.so, ${2}.dll); is CARGO_TARGET_DIR set correctly?" >&2
+  exit 1
 }
 
 echo_then_run() {

--- a/java/build_jni.sh
+++ b/java/build_jni.sh
@@ -137,8 +137,9 @@ build_desktop_for_arch () {
     fi
 
     echo_then_run cargo build -p libsignal-jni -p libsignal-jni-testing ${RUST_RELEASE:+--release} ${FEATURES:+--features "${FEATURES[*]}"} --target "$1"
-    copy_built_library "target/${1}/${RUST_RELEASE:-debug}" signal_jni "$lib_dir" "signal_jni_${suffix}"
-    copy_built_library "target/${1}/${RUST_RELEASE:-debug}" signal_jni_testing "$lib_dir" "signal_jni_testing_${suffix}"
+    local build_dir="${CARGO_TARGET_DIR:-target}/${1}/${RUST_RELEASE:-debug}"
+    copy_built_library "$build_dir" signal_jni "$lib_dir" "signal_jni_${suffix}"
+    copy_built_library "$build_dir" signal_jni_testing "$lib_dir" "signal_jni_testing_${suffix}"
     check_for_debug_level_logs_if_needed "$lib_dir"
 }
 

--- a/node/build_node_bridge.py
+++ b/node/build_node_bridge.py
@@ -73,7 +73,9 @@ def main(args: Optional[List[str]] = None) -> int:
     # Luckily, Python's sys.platform matches Node's OS names for our supported targets.
     parser.add_option('--os-name', default=sys.platform, metavar='OS',
                       help='specify Node OS name')
-    parser.add_option('--cargo-build-dir', default=os.path.join('..', 'target'), metavar='PATH',
+    parser.add_option('--cargo-build-dir',
+                      default=os.environ.get('CARGO_TARGET_DIR') or os.path.join('..', 'target'),
+                      metavar='PATH',
                       help='specify cargo build dir (default %default)')
     parser.add_option('--cargo-target', default=None,
                       help='specify cargo target')

--- a/swift/Package.swift
+++ b/swift/Package.swift
@@ -5,9 +5,13 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
+import Foundation
 import PackageDescription
 
-let rustBuildDir = "../target/debug/"
+// Honor a user-defined Cargo target directory (CARGO_TARGET_DIR) if set,
+// falling back to the workspace default of `<repo>/target`.
+let cargoTargetDir = ProcessInfo.processInfo.environment["CARGO_TARGET_DIR"] ?? "../target"
+let rustBuildDir = "\(cargoTargetDir)/debug/"
 
 let package = Package(
     name: "LibSignalClient",


### PR DESCRIPTION
Fixes #655.

The Java JNI, Node, and Swift build steps assumed the Cargo target directory was always `target` (relative to the workspace root). When a user configures a different target directory via `CARGO_TARGET_DIR`, Cargo builds the libraries there, but these scripts kept looking in `target/` and failed to find them.

`swift/build_ffi.sh` already honored `CARGO_TARGET_DIR` (`${CARGO_TARGET_DIR:-target}`); this change makes the rest of the client build scripts consistent with that convention.

## Changes

- **`java/build_jni.sh`** — read the desktop/server artifacts from `${CARGO_TARGET_DIR:-target}` instead of a hardcoded `target`. This is the exact line the issue points at. (The Android path already uses `cargo build --artifact-dir`, so it's unaffected.)
- **`node/build_node_bridge.py`** — default `--cargo-build-dir` to `CARGO_TARGET_DIR` when it's set. Previously the script unconditionally set `CARGO_BUILD_TARGET_DIR=../target`; since Cargo's `CARGO_TARGET_DIR` env var takes precedence over `CARGO_BUILD_TARGET_DIR`, a user with `CARGO_TARGET_DIR` set had Cargo build into their directory while the script looked in `../target` and found nothing.
- **`swift/Package.swift`** — derive the link path (`-L`) from `CARGO_TARGET_DIR`, falling back to `../target`.
- **`bin/build_helpers.sh`** — make `copy_built_library` fail with a clear error when no built library is found, instead of silently doing nothing. This is what made the original report confusing: a wrong target dir left the native library out of the resources dir, so the failure surfaced later as a `jar not found`/zip error in the Gradle packaging step rather than at the actual point of breakage. It now reports the directory searched and the library name, so any future path mismatch (e.g. a target dir set only via `.cargo/config.toml`, see below) fails loudly and actionably.

## Notes / scope

- Honors the `CARGO_TARGET_DIR` environment variable specifically (the documented, standard way to relocate the target dir, and what `build_ffi.sh` already keyed off). A target dir set only via `.cargo/config.toml`'s `build.target-dir` is out of scope here; resolving that reliably would mean shelling out to `cargo metadata`. With the `copy_built_library` change above, that case now fails with a clear error rather than a silent miss.
- Verified: `bash -n java/build_jni.sh`, `bash -n bin/build_helpers.sh`, `python3 -m py_compile node/build_node_bridge.py`, and `swift package describe` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)