### PR TITLE
protocol: fix ML-KEM parameter key type

### DIFF
--- a/rust/protocol/src/kem.rs
+++ b/rust/protocol/src/kem.rs
@@ -674,21 +674,32 @@ mod tests {
 
     #[test]
     fn test_dyn_parameters_consts() {
-        assert_eq!(
-            kyber1024::Parameters::SECRET_KEY_LENGTH,
-            kyber1024::Parameters.secret_key_length()
-        );
-        assert_eq!(
-            kyber1024::Parameters::PUBLIC_KEY_LENGTH,
-            kyber1024::Parameters.public_key_length()
-        );
-        assert_eq!(
-            kyber1024::Parameters::CIPHERTEXT_LENGTH,
-            kyber1024::Parameters.ciphertext_length()
-        );
-        assert_eq!(
-            kyber1024::Parameters::SHARED_SECRET_LENGTH,
-            kyber1024::Parameters.shared_secret_length()
-        );
+        fn assert_parameters<T: Parameters>(key_type: KeyType) {
+            assert_eq!(T::KEY_TYPE, key_type);
+            assert_eq!(
+                T::SECRET_KEY_LENGTH,
+                key_type.parameters().secret_key_length()
+            );
+            assert_eq!(
+                T::PUBLIC_KEY_LENGTH,
+                key_type.parameters().public_key_length()
+            );
+            assert_eq!(
+                T::CIPHERTEXT_LENGTH,
+                key_type.parameters().ciphertext_length()
+            );
+            assert_eq!(
+                T::SHARED_SECRET_LENGTH,
+                key_type.parameters().shared_secret_length()
+            );
+        }
+
+        assert_parameters::<kyber1024::Parameters>(KeyType::Kyber1024);
+
+        #[cfg(feature = "kyber768")]
+        assert_parameters::<kyber768::Parameters>(KeyType::Kyber768);
+
+        #[cfg(feature = "mlkem1024")]
+        assert_parameters::<mlkem1024::Parameters>(KeyType::MLKEM1024);
     }
 }

--- a/rust/protocol/src/kem/mlkem1024.rs
+++ b/rust/protocol/src/kem/mlkem1024.rs
@@ -16,7 +16,7 @@ use super::{
 pub(crate) struct Parameters;
 
 impl super::Parameters for Parameters {
-    const KEY_TYPE: KeyType = KeyType::Kyber1024;
+    const KEY_TYPE: KeyType = KeyType::MLKEM1024;
     const PUBLIC_KEY_LENGTH: usize = MlKem1024PublicKey::LENGTH;
     const SECRET_KEY_LENGTH: usize = MlKem1024PrivateKey::LENGTH;
     const CIPHERTEXT_LENGTH: usize = MlKem1024Ciphertext::LENGTH;


### PR DESCRIPTION
## Summary

- fixes the ML-KEM 1024 `Parameters::KEY_TYPE` value so it matches `KeyType::MLKEM1024`
- extends the existing KEM parameter-constant test so each enabled KEM checks its static `KEY_TYPE` against the dynamic `KeyType` dispatch

## Notes

The ML-KEM implementation still used the Kyber1024 key type in its `Parameters` impl, while `KeyType::MLKEM1024` dispatches to that impl

`Parameters::KEY_TYPE` is used when KEM encapsulation or decapsulation errors are mapped into `SignalProtocolError`. This keeps ML-KEM 1024 self-consistent with that mapping

This does not change serialized keys, ciphertexts, or successful KEM behavior

## Test plan

- `cargo test -p libsignal-protocol`
- `cargo test -p libsignal-protocol --all-features`
- `cargo clippy -p libsignal-protocol --all-targets --all-features -- -D warnings`
- `cargo test -p libsignal-protocol --features mlkem1024 test_dyn_parameters_consts`
- `cargo test -p libsignal-protocol --all-features kem::tests`
- `cargo fmt --all -- --check`
- `git diff --check`