### PR TITLE
Publish Android JNI libraries as JVM client classifiers

### DIFF
--- a/java/client/build.gradle
+++ b/java/client/build.gradle
@@ -108,6 +108,45 @@ processResources {
     dependsOn ':makeJniLibrariesDesktop'
 }
 
+def androidJniClassifiers = [
+    'android-aarch64': 'arm64-v8a',
+    'android-arm'    : 'armeabi-v7a',
+    'android-x86_64' : 'x86_64',
+    'android-x86'    : 'x86',
+]
+
+def androidJniOutputDirectory = layout.buildDirectory.dir('generated/android-jni')
+
+task collectAndroidJniLibrariesForJvm(type: Sync) {
+    dependsOn ':android:makeJniLibraries'
+    includeEmptyDirs = false
+
+    androidJniClassifiers.each { classifier, abi ->
+        from(rootProject.file("android/src/main/jniLibs/${abi}")) {
+            include 'libsignal_jni.so'
+            into classifier
+        }
+    }
+
+    into androidJniOutputDirectory
+}
+
+def androidJniJarTasks = [
+    'android-aarch64': 'androidAarch64Jar',
+    'android-arm'    : 'androidArmJar',
+    'android-x86_64' : 'androidX86_64Jar',
+    'android-x86'    : 'androidX86Jar',
+].collectEntries { classifier, taskName ->
+    [(classifier): task(taskName, type: Jar) {
+        dependsOn collectAndroidJniLibrariesForJvm
+        archiveClassifier.set(classifier)
+
+        from(androidJniOutputDirectory.map { it.dir(classifier) }) {
+            include 'libsignal_jni.so'
+        }
+    }]
+}
+
 // MARK: Publishing
 
 publishing {
@@ -117,6 +156,7 @@ publishing {
             from components.java
             artifact dokkaHtmlJar
             artifact dokkaJavadocJar
+            androidJniJarTasks.values().each { artifact it }
 
             pom {
                 name = base.archivesName.get()


### PR DESCRIPTION
### Summary

Add Android JNI libraries as classifier artifacts to the existing `libsignal-client` JVM publication.

The normal `libsignal-client` JAR remains unchanged and continues to provide the Java API. Android JNI libraries are published separately as architecture-specific classifier JARs containing only `libsignal_jni.so`.

### Published artifacts

For each Android ABI, the JVM client publication additionally produces:

```text
libsignal-client-<version>-android-aarch64.jar
libsignal-client-<version>-android-arm.jar
libsignal-client-<version>-android-x86_64.jar
libsignal-client-<version>-android-x86.jar
```

Each classifier JAR contains:

```text
libsignal_jni.so
```

The classifier artifacts are therefore usable independently from the normal JVM artifact while avoiding changes to the existing desktop JNI packaging.

### Implementation

The `:client` publication now:

1. depends on the existing Android JNI build;
2. collects the JNI libraries from the corresponding Android ABI directories;
3. creates one classifier JAR per Android ABI;
4. attaches those JARs to the existing `mavenJava` publication.

The existing desktop JNI artifacts and normal `libsignal-client` JAR are unchanged.

### Validation

The implementation was verified with the complete Android JNI build:

```text
aarch64-linux-android
armv7-linux-androideabi
x86_64-linux-android
i686-linux-android
```

The resulting local Maven publication contains:

```text
libsignal-client-<version>.jar
libsignal-client-<version>-android-aarch64.jar
libsignal-client-<version>-android-arm.jar
libsignal-client-<version>-android-x86_64.jar
libsignal-client-<version>-android-x86.jar
```

The classifier JARs were inspected and each contains exactly:

```text
META-INF/
META-INF/MANIFEST.MF
libsignal_jni.so
```

The publication was successfully built and published to Maven Local.

### Consumer model

The intended consumer model is:

```text
Desktop JVM
  → org.signal:libsignal-client:<version>

Android aarch64
  → org.signal:libsignal-client:<version>
  → org.signal:libsignal-client:<version>:android-aarch64
```

The normal artifact remains responsible for the Java classes; the classifier artifact supplies the platform-specific JNI library.

### Notes

This change intentionally does not introduce Android platform detection or modify consumers. Consumer-side selection of the appropriate classifier is handled separately.
